### PR TITLE
build(sdk): produce deterministic shared SDK archives

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -177,3 +177,12 @@ Espressif's LLVM fork for Xtensa). Exact revisions are recorded in
 Apache-2.0 WITH LLVM-exception; the compiler artifact carries both LLVM and WAMR license texts.
 WASI SDK is downloaded from its official release and verified against the locked SHA-256.
 No third-party compiler source or binary is committed into this repository.
+
+## Windows SDK embedded runtime
+
+Windows SDK manager distributions bundle CPython 3.13.12 (Python Software Foundation
+License Version 2 and the bundled third-party license notices) and pyserial 3.5
+(BSD-3-Clause). Exact upstream archives and SHA-256 values are locked in
+`tools/windows/runtime-sources.json`. Runtime archives must retain Python's
+`LICENSE.txt` and pyserial's wheel license metadata. Inno Setup is the build-time
+installer compiler; its license does not replace the bundled components' licenses.

--- a/tools/build_sdk_release.py
+++ b/tools/build_sdk_release.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Create the SDK once for GitHub and the documentation site.
+
+Inputs must be a clean source export. This command has no network side effects.
+"""
+from __future__ import annotations
+
+import argparse
+import gzip
+import hashlib
+import io
+import json
+import re
+import subprocess
+import tarfile
+from pathlib import Path
+
+DIRECTORIES = ('guest/sdk', 'guest/runtime', 'guest/abi', *(f'guest/apps/{name}' for name in
+               ('sdk-demo', 'snake', 'maze-evil', 'blocks', 'tilt', 'tomb-explorer')))
+WAMR_COMMIT = 'af07c787ac6f7d1d20555f97ddc184f5fc13731a'
+MARKER = 'EMBEDDED_BUNDLE_BUILDER: str | None = None'
+
+
+def collect(root: Path) -> dict[str, bytes]:
+    files: dict[str, bytes] = {}
+    tracked = None
+    try:
+        git_root = subprocess.check_output(['git', '-C', str(root), 'rev-parse', '--show-toplevel'], stderr=subprocess.DEVNULL, text=True).strip()
+        if Path(git_root).resolve() == root.resolve():
+            tracked = set(subprocess.check_output(['git', '-C', str(root), 'ls-files', '-z']).decode('utf-8').split('\0'))
+    except (OSError, subprocess.CalledProcessError):
+        pass  # Clean source archives do not contain a .git directory.
+    for directory in DIRECTORIES:
+        base = root / directory
+        if not base.is_dir():
+            raise ValueError(f'Missing SDK source directory: {directory}')
+        for path in sorted(base.rglob('*')):
+            relative = path.relative_to(root)
+            if path.is_symlink():
+                raise ValueError(f'Symlink is not allowed in SDK sources: {relative}')
+            if any(p in ('build', '__pycache__', '.git') or p.startswith('.') for p in relative.parts):
+                continue
+            if tracked is not None and relative.as_posix() not in tracked:
+                continue
+            if path.is_file() and path.name != 'README.md' and path.suffix != '.pyc':
+                files[relative.as_posix()] = path.read_bytes()
+    for name in ('generate_localization.py', 'analyze_sfx.py'):
+        files['libexec/' + name] = (root / 'tools' / name).read_bytes()
+    return files
+
+
+def build(root: Path) -> tuple[dict, bytes]:
+    root = root.resolve()
+    cli = (root / 'tools/micropixel').read_text(encoding='utf-8')
+    match = re.search(r'^VERSION = "([0-9]+\.[0-9]+\.[0-9]+)"$', cli, re.M)
+    if not match or cli.count(MARKER) != 1:
+        raise ValueError('SDK CLI must declare its version and one embedded-builder marker')
+    version = match[1]
+    files = collect(root)
+    builder = (root / 'tools/build_app_bundle.py').read_text(encoding='utf-8')
+    cli = cli.replace(MARKER, 'EMBEDDED_BUNDLE_BUILDER: str | None = ' + repr(builder))
+    files['micropixel'] = cli.encode('utf-8')
+    files['LICENSE'] = (root / 'LICENSE').read_bytes()
+    files['README.md'] = f'''# MicroPixel SDK {version}
+
+Restricted C++23 Guest SDK, Runtime, ABI and six example games.
+
+Start with [Quickstart](guest/sdk/QUICKSTART.md), then read
+[Publishing](guest/sdk/PUBLISHING.md) and [Graphics](guest/sdk/GRAPHICS.md).
+
+## Toolchain
+
+Use WASI SDK 33 and MicroPixel WAMR fork commit `{WAMR_COMMIT}`:
+https://github.com/78/wasm-micro-runtime (branch `wamr-host/esp-idf-psram`).
+The required AOT format is **v6**. `wamrc --version` reports `wamrc 2.4.3`,
+but that string alone does not establish compatibility.
+Upstream WAMR 2.4.3, 2.4.4, and 2.4.5 releases emit
+AOT format v5 and must not be substituted.
+
+Set WASI_SDK_PATH, WAMRC (RISC-V) and XTENSA_WAMRC (ESP32-S3).
+USB development also needs pyserial>=3.5,<4. Run the CLI using Python:
+
+```sh
+python micropixel init my-game --app-id local.my-game --title "My Game"
+python micropixel --transport usb run my-game
+```
+
+`publish --dry-run` validates **both** architectures without uploading.
+Real publishing requires separate developer authentication and authorization.
+
+Full environment instructions: https://micropixel.ai/docs/environment/
+
+Project sources are Apache-2.0; see LICENSE. WASI/LLVM and WAMR toolchains
+are distributed separately and carry their own third-party licenses.
+'''.encode('utf-8')
+    prefix = f'micropixel-sdk-{version}'
+    raw = io.BytesIO()
+    with tarfile.open(fileobj=raw, mode='w', format=tarfile.USTAR_FORMAT) as archive:
+        for name, content in sorted(files.items()):
+            info = tarfile.TarInfo(prefix + '/' + name)
+            info.size = len(content)
+            info.mode = 0o755 if name == 'micropixel' else 0o644
+            info.mtime = 0
+            info.uname = info.gname = 'micropixel'
+            archive.addfile(info, io.BytesIO(content))
+    # GzipFile gives a stable header (including OS byte) on every supported host.
+    compressed = io.BytesIO()
+    with gzip.GzipFile(fileobj=compressed, mode='wb', filename='', mtime=0, compresslevel=9) as output:
+        output.write(raw.getvalue())
+    data = compressed.getvalue()
+    metadata = {
+        'version': version, 'archiveName': prefix + '.tar.gz',
+        'sha256': hashlib.sha256(data).hexdigest(), 'sizeBytes': len(data),
+        'fileCount': len(files), 'toolchain': {
+            'wamrRepository': 'https://github.com/78/wasm-micro-runtime',
+            'wamrBranch': 'wamr-host/esp-idf-psram', 'wamrCommit': WAMR_COMMIT,
+            'wamrcReportedVersion': '2.4.3', 'aotFormatVersion': 6,
+        },
+    }
+    return metadata, data
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--workspace-root', type=Path, default=Path(__file__).resolve().parents[1])
+    parser.add_argument('--output-dir', type=Path, required=True)
+    args = parser.parse_args()
+    metadata, data = build(args.workspace_root)
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    target = args.output_dir / metadata['archiveName']
+    if target.exists() and target.read_bytes() != data:
+        raise SystemExit('Refusing to replace an existing SDK version with different content')
+    target.write_bytes(data)
+    (args.output_dir / 'release.json').write_text(json.dumps(metadata, indent=2) + '\n', encoding='utf-8')
+    (args.output_dir / 'sha256sums.txt').write_text(f"{metadata['sha256']}  {metadata['archiveName']}\n")
+    print(json.dumps(metadata))
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/tests/test_sdk_release.py
+++ b/tools/tests/test_sdk_release.py
@@ -1,0 +1,52 @@
+"""Verify SDK contents, determinism and the standalone CLI contract."""
+import hashlib
+import io
+import subprocess
+import sys
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+
+from tools import build_sdk_release as packager
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class SdkArchive(unittest.TestCase):
+    def test_archive_is_deterministic_and_standalone(self):
+        metadata, first = packager.build(ROOT)
+        self.assertEqual(packager.build(ROOT), (metadata, first))
+        self.assertEqual(hashlib.sha256(first).hexdigest(), metadata['sha256'])
+        with tempfile.TemporaryDirectory() as temporary, tarfile.open(fileobj=io.BytesIO(first)) as archive:
+            names = archive.getnames()
+            prefix = 'micropixel-sdk-' + metadata['version'] + '/'
+            self.assertTrue(all(name.startswith(prefix) for name in names))
+            self.assertFalse(any('/coastline/' in name or '/build/' in name or '/.env' in name for name in names))
+            self.assertIn(prefix + 'guest/sdk/GRAPHICS.md', names)
+            self.assertIn(prefix + 'LICENSE', names)
+            self.assertEqual(archive.getmember(prefix + 'micropixel').mode, 0o755)
+            archive.extractall(temporary, filter='data')
+            cli = Path(temporary) / prefix / 'micropixel'
+            version = subprocess.check_output([sys.executable, str(cli), '--version'], text=True)
+            self.assertIn(metadata['version'], version)
+            project = Path(temporary) / '中文 game'
+            subprocess.run([sys.executable, str(cli), 'init', str(project), '--app-id', 'test.sdk.hello'], check=True, capture_output=True)
+            self.assertTrue((project / 'app.json').is_file())
+            contents = cli.read_text(encoding='utf-8')
+            self.assertNotIn(packager.MARKER, contents)
+
+    def test_existing_version_cannot_be_overwritten(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            metadata, data = packager.build(ROOT)
+            destination = Path(temporary) / metadata['archiveName']
+            destination.write_bytes(b'existing release')
+            result = subprocess.run([sys.executable, str(ROOT / 'tools/build_sdk_release.py'),
+                                     '--output-dir', temporary], capture_output=True, text=True)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn('Refusing to replace', result.stderr)
+            self.assertEqual(destination.read_bytes(), b'existing release')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/windows/release_metadata.py
+++ b/tools/windows/release_metadata.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Produce immutable archives and machine-readable release manifests."""
+from __future__ import annotations
+import argparse
+import hashlib
+import json
+import re
+import zipfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+def file_digest(path: Path) -> str:
+    sha = hashlib.sha256()
+    with path.open('rb') as stream:
+        while block := stream.read(1024 * 1024):
+            sha.update(block)
+    return sha.hexdigest()
+
+
+def identifier(value: str) -> str:
+    if not re.fullmatch(r'[0-9]+\.[0-9]+\.[0-9]+', value):
+        raise ValueError('Invalid SDK version')
+    return value
+
+
+def write(path: Path, data: bytes):
+    if path.exists() and path.read_bytes() != data:
+        raise ValueError(f'Refusing to overwrite immutable release asset: {path.name}')
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(data)
+
+
+def write_json(path: Path, value: dict):
+    write(path, (json.dumps(value, indent=2, sort_keys=True) + '\n').encode())
+
+
+def asset(path: Path, base: str, root: str) -> dict:
+    return {'name': path.name, 'url': base + '/' + path.name, 'sha256': file_digest(path),
+            'size_bytes': path.stat().st_size, 'root': root}
+
+
+def archive(source: Path, destination: Path, prefix: str):
+    import io
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, 'w', compression=zipfile.ZIP_DEFLATED) as output:
+        for path in sorted(source.rglob('*')):
+            if path.is_symlink():
+                raise ValueError('Release archives cannot contain links')
+            if path.is_file() and '__pycache__' not in path.parts:
+                info = zipfile.ZipInfo(prefix + '/' + path.relative_to(source).as_posix(), date_time=(2020, 1, 1, 0, 0, 0))
+                info.compress_type = zipfile.ZIP_DEFLATED
+                info.external_attr = 0o100644 << 16
+                output.writestr(info, path.read_bytes())
+    write(destination, buffer.getvalue())
+
+
+def toolchain(verified: Path, output: Path, repository: str):
+    source_path = ROOT / 'tools/windows/toolchain-sources.json'
+    sources = json.loads(source_path.read_text())
+    source_sha = file_digest(source_path)
+    toolchain_id = 'windows-x64-' + source_sha[:16]
+    tag = 'toolchain-' + toolchain_id
+    base = f'https://github.com/{repository}/releases/download/{tag}'
+    packages = {}
+    for target, key in [('riscv32-ilp32f', 'wamrc_riscv'), ('xtensa', 'wamrc_xtensa')]:
+        directory = verified / ('wamrc-windows-x64-' + target)
+        receipt = json.loads((directory / 'build-info.json').read_text())
+        if receipt['source_lock_sha256'] != source_sha or receipt['target'] != target or receipt['sha256'] != file_digest(directory / 'wamrc.exe'):
+            raise ValueError('Compiler provenance differs from pinned source manifest')
+        filename = f'wamrc-{toolchain_id}-{target}.zip'
+        archive(directory, output / filename, 'wamrc')
+        packages[key] = asset(output / filename, base, 'wamrc')
+    wasi = sources['wasi']
+    # Size is obtained from the already verified official archive in the producer job.
+    wasi_archive = verified / 'wasi.tar.gz'
+    if file_digest(wasi_archive) != wasi['sha256']:
+        raise ValueError('WASI archive checksum mismatch')
+    packages['wasi'] = {'name': 'wasi-sdk-33', 'url': wasi['url'], 'sha256': wasi['sha256'],
+                        'size_bytes': wasi_archive.stat().st_size, 'root': wasi['directory']}
+    write_json(output / 'toolchain.json', {'schema_version': 1, 'toolchain_id': toolchain_id,
+                'source_lock_sha256': source_sha, 'sources': sources, 'platforms': {'windows-x64': packages}})
+    return tag
+
+
+def sdk(sdk_directory: Path, toolchain_path: Path, output: Path, repository: str):
+    metadata = json.loads((sdk_directory / 'release.json').read_text())
+    version = identifier(metadata['version'])
+    toolchain = json.loads(toolchain_path.read_text())
+    if toolchain['source_lock_sha256'] != file_digest(ROOT / 'tools/windows/toolchain-sources.json'):
+        raise ValueError('SDK toolchain does not match pinned source manifest')
+    base = f'https://github.com/{repository}/releases/download/sdk-v{version}'
+    sdk_asset = asset(sdk_directory / metadata['archiveName'], base, 'micropixel-sdk-' + version)
+    if sdk_asset['sha256'] != metadata['sha256']:
+        raise ValueError('SDK archive checksum mismatch')
+    write_json(output / 'sdk-manifest.json', {'schema_version': 1, 'sdk_version': version,
+        'toolchain_id': toolchain['toolchain_id'], 'sdk': sdk_asset, 'platforms': toolchain['platforms'],
+        'compatibility': {'lock_schema': 1, 'aot_version': 6, 'wamr_commit': toolchain['sources']['wamr_commit']},
+        'release_notes_url': f'https://github.com/{repository}/releases/tag/sdk-v{version}'})
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('kind', choices=['toolchain', 'sdk'])
+    parser.add_argument('--input', required=True, type=Path)
+    parser.add_argument('--output', required=True, type=Path)
+    parser.add_argument('--toolchain', type=Path)
+    parser.add_argument('--repository', default='78/micropixel')
+    args = parser.parse_args()
+    args.output.mkdir(parents=True, exist_ok=True)
+    if args.kind == 'toolchain':
+        print(toolchain(args.input, args.output, args.repository))
+    else:
+        sdk(args.input, args.toolchain, args.output, args.repository)
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/windows/runtime-sources.json
+++ b/tools/windows/runtime-sources.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "python": {
+    "version": "3.13.12",
+    "url": "https://www.python.org/ftp/python/3.13.12/python-3.13.12-embed-amd64.zip",
+    "size_bytes": 10941233,
+    "sha256": "76f238f606250c87c6beac75dccd35ee99070a13490555936abb6cb64ecce3d0"
+  },
+  "pyserial": {
+    "version": "3.5",
+    "url": "https://files.pythonhosted.org/packages/07/bc/587a445451b253b285629263eb51c2d8e9bcea4fc97826266d186f96f558/pyserial-3.5-py2.py3-none-any.whl",
+    "size_bytes": 90585,
+    "sha256": "c4451db6ba391ca6ca299fb3ec7bae67a5c55dde170964c7a14ceefec02f2cf0"
+  }
+}


### PR DESCRIPTION
Move SDK archive generation into the main repository and define pinned release inputs. The same immutable archive can be consumed by GitHub and the documentation site. Validation: deterministic archive and standalone CLI tests passed; full p4 test gate passed.