### PR TITLE
ci(sdk): publish immutable verified Windows toolchains

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Release archives and source-lock digests must be identical on Windows and POSIX.
+* text=auto eol=lf
+*.png -text
+*.jpg -text
+*.jpeg -text
+*.zip -text
+*.ttf -text
+*.woff2 -text
+*.bin -text

--- a/.github/workflows/toolchain-release.yml
+++ b/.github/workflows/toolchain-release.yml
@@ -1,0 +1,41 @@
+name: Publish verified Windows toolchain
+on:
+  workflow_dispatch:
+    inputs:
+      verification_run:
+        description: Successful Windows toolchain verification run ID
+        required: true
+        type: string
+permissions:
+  contents: write
+  actions: read
+concurrency:
+  group: publish-windows-toolchain
+  cancel-in-progress: false
+jobs:
+  publish:
+    runs-on: windows-2022
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+      VERIFICATION_RUN: ${{ inputs.verification_run }}
+      PYTHONUTF8: '1'
+      PYTHONIOENCODING: utf-8
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: '3.13.12'
+      - name: Verify provenance and download successful artifacts
+        run: python tools/windows/collect_verified_toolchain.py --run $env:VERIFICATION_RUN --output build/verified
+      - name: Collect pinned app-local runtime
+        shell: pwsh
+        run: ./tools/windows/package_crt.ps1 -Output build/verified/msvc-crt
+      - name: Create immutable toolchain archives
+        shell: pwsh
+        run: |
+          $tag = python tools/windows/release_metadata.py toolchain --input build/verified --output build/release --repository $env:GH_REPO
+          if ($LASTEXITCODE -ne 0) { throw 'Toolchain packaging failed' }
+          "TOOLCHAIN_TAG=$tag" >> $env:GITHUB_ENV
+      - name: Publish immutable toolchain release
+        run: python tools/windows/publish_toolchain.py --directory build/release --tag $env:TOOLCHAIN_TAG

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -186,3 +186,12 @@ License Version 2 and the bundled third-party license notices) and pyserial 3.5
 `tools/windows/runtime-sources.json`. Runtime archives must retain Python's
 `LICENSE.txt` and pyserial's wheel license metadata. Inno Setup is the build-time
 installer compiler; its license does not replace the bundled components' licenses.
+
+Windows WASI compiler deployment also includes app-local Microsoft Visual C++
+Runtime 2015–2022 files, version 14.44.35211.0, from the Visual Studio 2022
+redistributable directory. File hashes are pinned in `tools/windows/msvc-crt-sources.json`.
+These proprietary Microsoft components are covered by the
+[Microsoft runtime license](https://visualstudio.microsoft.com/license-terms/vs2022-cruntime/)
+and [distributable list](https://learn.microsoft.com/en-us/visualstudio/releases/2022/redistribution),
+not MicroPixel's Apache-2.0 license. The package retains a dedicated Microsoft notice.
+MicroPixel updates must also deliver updates to this app-local runtime.

--- a/tools/windows/collect_verified_toolchain.py
+++ b/tools/windows/collect_verified_toolchain.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Accept artifacts only from a successful same-repository verification run."""
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import urllib.request
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--run', required=True)
+    parser.add_argument('--output', type=Path, required=True)
+    args = parser.parse_args()
+    if not re.fullmatch(r'[0-9]+', args.run):
+        raise SystemExit('Invalid verification run ID')
+    repository = os.environ['GH_REPO']
+    info = json.loads(subprocess.check_output(['gh', 'api', f'repos/{repository}/actions/runs/{args.run}']))
+    if info['conclusion'] != 'success' or info['head_repository']['full_name'] != repository or info['path'] != '.github/workflows/windows-toolchain.yml':
+        raise SystemExit('Run is not a successful same-repository Windows toolchain verification')
+    sha = info['head_sha']
+    if not re.fullmatch(r'[0-9a-f]{40}', sha):
+        raise SystemExit('Invalid verified commit')
+    subprocess.run(['git', 'fetch', '--depth=1', 'origin', sha], check=True)
+    for relative in ('tools/windows/toolchain-sources.json', 'tools/windows/build_toolchain.py'):
+        verified = subprocess.check_output(['git', 'show', f'{sha}:{relative}'])
+        if verified.replace(b'\r\n', b'\n') != (ROOT / relative).read_bytes().replace(b'\r\n', b'\n'):
+            raise SystemExit(f'Verified build recipe differs from release checkout: {relative}')
+    args.output.mkdir(parents=True, exist_ok=True)
+    for target in ('riscv32-ilp32f', 'xtensa'):
+        name = 'wamrc-windows-x64-' + target
+        subprocess.run(['gh', 'run', 'download', args.run, '--name', name, '--dir', str(args.output / name)], check=True)
+    wasi = json.loads((ROOT / 'tools/windows/toolchain-sources.json').read_text())['wasi']
+    archive = args.output / 'wasi.tar.gz'
+    urllib.request.urlretrieve(wasi['url'], archive)
+    with archive.open('rb') as stream:
+        checksum = hashlib.file_digest(stream, 'sha256').hexdigest()
+    if checksum != wasi['sha256']:
+        raise SystemExit('Official WASI checksum mismatch')
+    (args.output / 'verification.json').write_text(json.dumps({'run': args.run, 'commit': sha, 'repository': repository}) + '\n')
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/windows/msvc-crt-sources.json
+++ b/tools/windows/msvc-crt-sources.json
@@ -1,0 +1,59 @@
+{
+  "files": {
+    "concrt140.dll": {
+      "sha256": "2405355f0a58067b258f8df33c327e3a3d716eaac5a3a5aebb757842d85bd376",
+      "size_bytes": 324208,
+      "version": "14.44.35211.0"
+    },
+    "msvcp140.dll": {
+      "sha256": "0f885b509a685d2bbfa652fed26b5fb31d88fbdab0a978c641d1c7b8aa460aa9",
+      "size_bytes": 557728,
+      "version": "14.44.35211.0"
+    },
+    "msvcp140_1.dll": {
+      "sha256": "bfad5aef4c63a669e3c140655cdfdf395b6c979b400a447bd5dcb65ed8826c3d",
+      "size_bytes": 35952,
+      "version": "14.44.35211.0"
+    },
+    "msvcp140_2.dll": {
+      "sha256": "3ea06f0ee098b4823cb79599df3780e7f23cce52c19aac31d2a0d47efe33a5e9",
+      "size_bytes": 280200,
+      "version": "14.44.35211.0"
+    },
+    "msvcp140_atomic_wait.dll": {
+      "sha256": "640b2aefced484d0368eea5bdd06addd0658a3a70a49256e560d6923b404a479",
+      "size_bytes": 50304,
+      "version": "14.44.35211.0"
+    },
+    "msvcp140_codecvt_ids.dll": {
+      "sha256": "f2069a52880ec885ee7f0511186100eb7fada0411a2b4948fafea7735b878a18",
+      "size_bytes": 31872,
+      "version": "14.44.35211.0"
+    },
+    "vccorlib140.dll": {
+      "sha256": "19839407c3fdbc824e5bce189bf68ddf8097f12ec28b757797ffa0415c144ddd",
+      "size_bytes": 352384,
+      "version": "14.44.35211.0"
+    },
+    "vcruntime140.dll": {
+      "sha256": "d5e4d9a3e835fa679450145d6a7d94e36573a509317111904d9b3712c30d9066",
+      "size_bytes": 124544,
+      "version": "14.44.35211.0"
+    },
+    "vcruntime140_1.dll": {
+      "sha256": "1f2d41c4aa5db0bc33ebf7b66d72943a817d7ce6cbe880502a9403823633093f",
+      "size_bytes": 49792,
+      "version": "14.44.35211.0"
+    },
+    "vcruntime140_threads.dll": {
+      "sha256": "219915cf20822f34d5e7c1fdd4e21ae7f3396881096c51036225fb8f84b47afa",
+      "size_bytes": 38528,
+      "version": "14.44.35211.0"
+    }
+  },
+  "license": "https://visualstudio.microsoft.com/license-terms/vs2022-cruntime/",
+  "redistribution": "https://learn.microsoft.com/en-us/visualstudio/releases/2022/redistribution",
+  "schema_version": 1,
+  "source": "Visual Studio 2022 VC/Redist/MSVC/<version>/x64/Microsoft.VC143.CRT",
+  "version": "14.44.35112"
+}

--- a/tools/windows/package_crt.ps1
+++ b/tools/windows/package_crt.ps1
@@ -1,0 +1,24 @@
+# Copy only hash-pinned Microsoft redistributable files; never use System32 DLLs.
+[CmdletBinding()]
+param([Parameter(Mandatory=$true)][string]$Output)
+$ErrorActionPreference = 'Stop'
+$pin = Get-Content -Raw (Join-Path $PSScriptRoot 'msvc-crt-sources.json') | ConvertFrom-Json
+$vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+$vs = & $vswhere -latest -products '*' -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+$directory = Join-Path $vs "VC\Redist\MSVC\$($pin.version)\x64\Microsoft.VC143.CRT"
+New-Item -ItemType Directory -Force -Path $Output | Out-Null
+foreach ($file in $pin.files.PSObject.Properties) {
+    $source = Join-Path $directory $file.Name
+    if ((Get-FileHash -LiteralPath $source -Algorithm SHA256).Hash.ToLowerInvariant() -ne $file.Value.sha256) {
+        throw "Pinned Microsoft runtime changed: $($file.Name); review the source lock before rebuilding"
+    }
+    Copy-Item -LiteralPath $source -Destination (Join-Path $Output $file.Name)
+}
+@"
+Microsoft Visual C++ Runtime 2015-2022
+Copyright Microsoft Corporation. All rights reserved.
+App-local deployment from the Visual Studio 2022 redistributable directory.
+License terms: $($pin.license)
+Distributable files list: $($pin.redistribution)
+MicroPixel's Apache-2.0 license does not apply to these Microsoft components.
+"@ | Set-Content -LiteralPath (Join-Path $Output 'LICENSE-MICROSOFT-CRT.txt') -Encoding UTF8

--- a/tools/windows/publish_toolchain.py
+++ b/tools/windows/publish_toolchain.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Create a draft, upload verified assets once, then publish the toolchain."""
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+
+
+def run(*args):
+    subprocess.run(list(args), check=True)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--directory', required=True, type=Path)
+    parser.add_argument('--tag', required=True)
+    args = parser.parse_args()
+    if not re.fullmatch(r'toolchain-windows-x64-[0-9a-f]{16}', args.tag):
+        raise SystemExit('Invalid immutable toolchain tag')
+    manifest = json.loads((args.directory / 'toolchain.json').read_text())
+    if args.tag != 'toolchain-' + manifest['toolchain_id']:
+        raise SystemExit('Tag differs from manifest')
+    existing = subprocess.check_output(['git', 'ls-remote', '--tags', 'origin', 'refs/tags/' + args.tag], text=True)
+    if existing.strip():
+        raise SystemExit('Published toolchain tags are immutable; refusing to overwrite')
+    assets = sorted([args.directory / 'toolchain.json', *args.directory.glob('*.zip')])
+    checksums = []
+    for path in assets:
+        with path.open('rb') as stream:
+            checksums.append(hashlib.file_digest(stream, 'sha256').hexdigest() + '  ' + path.name)
+    checksum_file = args.directory / 'sha256sums.txt'
+    checksum_file.write_text('\n'.join(checksums) + '\n')
+    notes = args.directory / 'release-notes.md'
+    notes.write_text('Fixed Windows x64 AOT v6 toolchains and app-local MSVC runtime.\n\n'
+                     'Both target compilers passed native Windows Guest example and Bundle validation. '
+                     'This toolchain release is separate from SDK release channels.\n')
+    run('gh', 'release', 'create', args.tag, '--draft', '--prerelease', '--latest=false',
+        '--target', os.environ['GITHUB_SHA'], '--title', args.tag, '--notes-file', str(notes))
+    run('gh', 'release', 'upload', args.tag, *map(str, [*assets, checksum_file]))
+    run('gh', 'release', 'edit', args.tag, '--draft=false', '--prerelease', '--latest=false')
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/windows/release_metadata.py
+++ b/tools/windows/release_metadata.py
@@ -58,18 +58,32 @@ def toolchain(verified: Path, output: Path, repository: str):
     source_path = ROOT / 'tools/windows/toolchain-sources.json'
     sources = json.loads(source_path.read_text())
     source_sha = file_digest(source_path)
-    toolchain_id = 'windows-x64-' + source_sha[:16]
+    crt_lock = ROOT / 'tools/windows/msvc-crt-sources.json'
+    recipe_sha = file_digest(ROOT / 'tools/windows/build_toolchain.py')
+    identity = hashlib.sha256((source_sha + recipe_sha + file_digest(crt_lock)).encode()).hexdigest()
+    toolchain_id = 'windows-x64-' + identity[:16]
     tag = 'toolchain-' + toolchain_id
     base = f'https://github.com/{repository}/releases/download/{tag}'
     packages = {}
     for target, key in [('riscv32-ilp32f', 'wamrc_riscv'), ('xtensa', 'wamrc_xtensa')]:
         directory = verified / ('wamrc-windows-x64-' + target)
         receipt = json.loads((directory / 'build-info.json').read_text())
-        if receipt['source_lock_sha256'] != source_sha or receipt['target'] != target or receipt['sha256'] != file_digest(directory / 'wamrc.exe'):
+        # The bootstrap verification predates .gitattributes; accept its CRLF
+        # checkout digest only when it is exactly the same pinned source text.
+        bootstrap_sha = hashlib.sha256(source_path.read_bytes().replace(b'\r\n', b'\n').replace(b'\n', b'\r\n')).hexdigest()
+        if receipt['source_lock_sha256'] not in (source_sha, bootstrap_sha) or receipt['target'] != target or receipt['sha256'] != file_digest(directory / 'wamrc.exe'):
             raise ValueError('Compiler provenance differs from pinned source manifest')
         filename = f'wamrc-{toolchain_id}-{target}.zip'
         archive(directory, output / filename, 'wamrc')
         packages[key] = asset(output / filename, base, 'wamrc')
+    crt_sources = json.loads(crt_lock.read_text())
+    crt_directory = verified / 'msvc-crt'
+    for name, pinned in crt_sources['files'].items():
+        if file_digest(crt_directory / name) != pinned['sha256']:
+            raise ValueError('MSVC runtime provenance mismatch: ' + name)
+    crt_archive = output / ('msvc-crt-' + toolchain_id + '.zip')
+    archive(crt_directory, crt_archive, 'crt')
+    packages['msvc_crt'] = asset(crt_archive, base, 'crt')
     wasi = sources['wasi']
     # Size is obtained from the already verified official archive in the producer job.
     wasi_archive = verified / 'wasi.tar.gz'
@@ -78,7 +92,7 @@ def toolchain(verified: Path, output: Path, repository: str):
     packages['wasi'] = {'name': 'wasi-sdk-33', 'url': wasi['url'], 'sha256': wasi['sha256'],
                         'size_bytes': wasi_archive.stat().st_size, 'root': wasi['directory']}
     write_json(output / 'toolchain.json', {'schema_version': 1, 'toolchain_id': toolchain_id,
-                'source_lock_sha256': source_sha, 'sources': sources, 'platforms': {'windows-x64': packages}})
+                'source_lock_sha256': source_sha, 'build_recipe_sha256': recipe_sha, 'msvc_crt': crt_sources, 'sources': sources, 'platforms': {'windows-x64': packages}})
     return tag
 
 


### PR DESCRIPTION
Publish compiler artifacts only from a successful same-repository dual-architecture verification with matching pinned recipes. Package the exact MSVC runtime beside WASI tools without requiring administrator installation. The producer preserves old release assets and separates toolchain tags from SDK channels.