### PR TITLE
feat(windows): add per-user GUI and silent Preview installer

### DIFF
--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -27,7 +27,7 @@ jobs:
           $vs = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products '*' -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
           $vcvars = Join-Path $vs 'VC\Auxiliary\Build\vcvars64.bat'
           cmd /c "`"$vcvars`" >nul && set" | ForEach-Object {
-            if ($_ -match '^([^=]+)=(.*)$') { "$($Matches[1])=$($Matches[2])" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8 }
+            if ($_ -match '^([^=]+)=(.*)$' -and $Matches[1] -in @('Path', 'INCLUDE', 'LIB', 'LIBPATH', 'VCINSTALLDIR', 'VCToolsInstallDir', 'VCToolsRedistDir', 'VCToolsVersion', 'WindowsSdkDir', 'WindowsSDKVersion')) { "$($Matches[1])=$($Matches[2])" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8 }
           }
       - name: Build unsigned Preview installer
         run: python tools/windows/build_installer.py --output 'build/中文 installer'

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -1,0 +1,47 @@
+name: Windows Preview installer
+on:
+  workflow_dispatch:
+  push:
+    branches: ['codex/windows-sdk-installer']
+  pull_request:
+    paths: ['tools/windows/**', 'tools/manager/**', 'tools/micropixel', '.github/workflows/windows-installer.yml']
+permissions:
+  contents: read
+concurrency:
+  group: windows-installer-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+jobs:
+  installer:
+    runs-on: windows-2022
+    env:
+      PYTHONUTF8: '1'
+      PYTHONIOENCODING: utf-8
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: '3.13.12'
+      - name: Activate MSVC x64
+        shell: pwsh
+        run: |
+          $vs = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products '*' -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+          $vcvars = Join-Path $vs 'VC\Auxiliary\Build\vcvars64.bat'
+          cmd /c "`"$vcvars`" >nul && set" | ForEach-Object {
+            if ($_ -match '^([^=]+)=(.*)$') { "$($Matches[1])=$($Matches[2])" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8 }
+          }
+      - name: Build unsigned Preview installer
+        run: python tools/windows/build_installer.py --output 'build/中文 installer'
+      - name: Test silent install and uninstall
+        shell: pwsh
+        run: |
+          $metadata = Get-Content -Raw 'build/中文 installer/windows-installer.json' | ConvertFrom-Json
+          ./tools/windows/test_installer.ps1 -Installer (Join-Path 'build/中文 installer' $metadata.name)
+      - name: Upload installer for review
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: windows-preview-installer
+          path: |
+            build/中文 installer/micropixel-setup-*.exe
+            build/中文 installer/windows-installer.json
+            build/中文 installer/runtime/micropixel-manager-*.zip
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -207,3 +207,5 @@ micropixel --transport usb run
 其他依赖的归属与例外见 [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md)。
 
 贡献前请阅读 [CONTRIBUTING.md](CONTRIBUTING.md)；安全问题请按 [SECURITY.md](SECURITY.md) 私下报告。
+
+Windows 游戏开发使用 [SDK Preview 安装指南](docs/development/windows-sdk.zh-CN.md)；安装器仅准备 Guest 工具链，不包含固件开发环境。

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,3 +47,7 @@ Espressif 官方支持渠道取得。其他板卡和器件信息同样只引用�
 
 新的硬件引用只记录官方来源、型号、版本和必要的校验值；除非再分发许可明确允许，
 不把第三方二进制文档纳入版本控制。
+
+- [Windows SDK 真机验收](development/windows-acceptance.zh-CN.md)：安装、AI 命令、更新回退与双架构设备测试清单（安装器 Preview 就绪后执行）。
+
+- [Windows SDK 安装与版本管理](development/windows-sdk.zh-CN.md)

--- a/docs/development/windows-acceptance.zh-CN.md
+++ b/docs/development/windows-acceptance.zh-CN.md
@@ -1,0 +1,112 @@
+# Windows 10 SDK 真机验收
+
+本清单针对 Windows 安装与版本管理项目。当前第一阶段只提供 Windows 工具链 CI，尚未发布安装器；
+以下 setup/doctor/sdk/JSON 命令属于待验收的安装管理接口，必须使用该项目后续 Preview 包，不能用 SDK 0.15.6 代替。
+CI 通过不能替代本清单。没有执行的项目标记 `not_run`，不能填写通过。
+
+## 准备
+
+- Windows 10 22H2 x64，普通用户账号，最好用户名包含中文。
+- 一款 P4/S31、一款 S3、两根可传输数据的 USB 线，设备已装匹配固件。
+- Preview Release 中的安装包、摘要、对应版本的本文及辅助脚本。
+- 两个可用的 SDK 测试版本 A/B；由发布维护者提供实际版本号，禁止伪造未发布版本。
+- 测试商店发布时使用专用 App ID，不使用已有正式应用。
+
+记录安装包版本、SDK A/B 版本、系统版本、设备板型和固件版本，不记录设备 MAC、凭据或配对码。
+清理旧开发工具 PATH 后测试；无需卸载电脑上其他项目使用的 Python 或编译器。
+
+## 安装和通用命令
+
+先根据 Release 清单检查 `Get-FileHash .\micropixel-setup.exe -Algorithm SHA256`。
+GUI 安装直接双击。静默安装使用同一包：
+
+```powershell
+$process = Start-Process -FilePath '.\micropixel-setup.exe' -ArgumentList '/VERYSILENT /SUPPRESSMSGBOXES /SP- /NORESTART /LOG="install.log"' -Wait -PassThru
+if ($process.ExitCode -ne 0) { throw "Installer failed: $($process.ExitCode)" }
+$mp = "$env:LOCALAPPDATA\MicroPixel\bin\micropixel.exe"
+& $mp setup --yes --json
+if ($LASTEXITCODE -ne 0) { throw 'Tool preparation failed' }
+& $mp doctor --json
+```
+
+安装器成功不代表环境就绪。doctor 必须返回 `ok: true` 和 `result.ready: true`。
+Preview 的系统安全提示需要人工核对，不关闭系统安全功能、不绕过拦截。
+
+创建项目：
+
+```powershell
+& $mp init '.\中文 游戏\hello' --app-id local.windows.hello --title 'Windows Hello' --json
+Set-Location '.\中文 游戏\hello'
+& $mp build --aot-target riscv32-ilp32f --json
+& $mp package --aot-target riscv32-ilp32f --json
+& $mp package --aot-target xtensa --json
+```
+
+连接设备后的命令：
+
+```powershell
+& $mp port list
+# 仅替换为上一步确认的端口；两台设备时必须显式选择。
+& $mp --transport usb --port COM7 run --no-follow --json
+& $mp --transport usb --port COM7 screenshot --output '.\screen.jpg'
+& $mp --transport usb --port COM7 app stop
+& $mp --transport usb --port COM7 run
+# 检查持续日志后 Ctrl-C：电脑端结束跟随，设备 App 继续运行。
+```
+
+## 结果表
+
+每项填 `pass`、`fail` 或 `not_run`，失败补充最短复现步骤。不要把完整串口日志粘贴进报告。
+
+| 编号 | 操作 | 预期结果 | 结果 |
+|---|---|---|---|
+| W01 | GUI 安装 | 无需另装开发工具，向导显示环境就绪 | not_run |
+| W02 | 新开 PowerShell 执行 doctor --json | PATH 正确、单个有效 JSON、双架构工具可用 | not_run |
+| W03 | 卸载后静默安装 | 无向导、无隐藏等待，退出码准确 | not_run |
+| W04 | 不新开终端，用绝对路径运行启动器 | 不重启电脑即可使用 | not_run |
+| W05 | 中文和空格目录内构建两次，再改一个头文件构建 | 第一次成功，第二次复用，改头文件正确重编译 | not_run |
+| W06 | 分别打包 RISC-V/Xtensa | 目标、SDK、工具链和产物位置正确 | not_run |
+| W07 | P4/S31 安装运行 | 画面、输入、日志正常 | not_run |
+| W08 | S3 安装运行 | 架构识别正确、画面和输入正常 | not_run |
+| W09 | 截图、停止、重新运行 | 图片有效，App 状态与命令一致 | not_run |
+| W10 | 拔插、串口被占用、两台设备同时连接 | 明确报错、不挂死、不选错设备，释放后恢复 | not_run |
+| W11 | 跟随日志时 Ctrl-C | 仅结束电脑端日志，游戏继续运行 | not_run |
+| W12 | A 项目检查更新并打包 | 提醒 B，锁文件未变化，构建仍成功 | not_run |
+| W13 | 两个 A 项目，仅升级其中一个到 B | 升级项目重编译，另一个仍使用 A | not_run |
+| W14 | 将升级项目切回 A | 源码不变，可用缓存恢复 A | not_run |
+| W15 | 下载中断网，然后重试 | 不假报成功、不破坏旧版本，可恢复 | not_run |
+| W16 | 准备依赖后断网构建 | 构建通过，更新状态明确离线 | not_run |
+| W17 | 专用 App 预检，单独授权后上传 | 双架构通过，商店版本正确 | not_run |
+| W18 | 更新管理组件、卸载重装 | PATH 无重复、项目保留、缓存按选择处理 | not_run |
+| W19 | 检查安全提示/签名 | Preview 提示如实记录；稳定包签名有效 | not_run |
+
+更新实验（把 A/B 替换为 Release 提供的实际版本）：
+
+```powershell
+& $mp sdk use A --yes --json
+& $mp sdk status --check --json
+Get-FileHash .\micropixel.lock.json
+& $mp package --aot-target riscv32-ilp32f --json
+Get-FileHash .\micropixel.lock.json  # W12：与上次相同。
+& $mp sdk use B --yes --json
+& $mp build --aot-target riscv32-ilp32f --json
+& $mp sdk use A --yes --offline --json
+& $mp build --aot-target riscv32-ilp32f --offline --json
+```
+
+W17 先执行 `publish --dry-run --json`；真实上传必须另行授权并登录，不由辅助脚本自动触发。
+
+## 收集报告
+
+运行 [collect_acceptance.ps1](../../tools/windows/collect_acceptance.ps1)：
+
+```powershell
+.\collect_acceptance.ps1 -MicroPixel $mp -Output '.\acceptance.json'
+```
+
+脚本只调用离线诊断，记录系统版本、受限制的版本字段、退出码和空的 W01–W19 结果表；
+不安装、不升级、不操作设备、不上传数据。自行填写人工结果，分享前检查备注中没有个人路径或凭据。
+安装日志只留本地；定位问题时另行提供经过脱敏的最小片段。
+
+稳定发布须完成 W01–W19、解决关键故障、验证两个架构实际运行并提供签名安装包。
+性能改进需要同一设备和场景对比 A/B，不以“更新到最新版”代替性能验收。

--- a/docs/development/windows-sdk.zh-CN.md
+++ b/docs/development/windows-sdk.zh-CN.md
@@ -1,0 +1,82 @@
+# Windows SDK 安装与版本管理
+
+目标系统为 Windows 10 22H2 x64。当前分支正在实现 Preview，安装器须在 Windows 双架构编译验证通过后发布；
+SDK 0.15.6 的独立归档不包含本文的安装管理组件。macOS 继续使用原有 SDK 流程。
+
+## 安装契约
+
+每个 SDK Release 提供同一个 GUI/静默安装包、`sdk-manifest.json`、安装包下载清单与 SHA-256。
+安装器按当前用户安装到 `%LOCALAPPDATA%\MicroPixel`，不要求管理员权限；
+内置 Python 3.13.12、pyserial 3.5 和管理组件，不要求用户安装 Git、CMake、LLVM、ESP-IDF 或 WSL。
+依赖准备下载清单指定的 WASI SDK 33 和两种固定版本 `wamrc.exe`。
+
+新终端中使用 `micropixel`；当前终端尚未刷新 PATH 时使用：
+
+```powershell
+$mp = "$env:LOCALAPPDATA\MicroPixel\bin\micropixel.exe"
+& $mp setup --yes --json
+& $mp doctor --json
+```
+
+以最后一次 `doctor` 的 `ok: true`、`result.ready: true` 为环境可用标准。
+安装器成功退出本身不代表依赖下载成功。断网后重新执行 setup；已完整验证的归档会复用。
+未签名 Preview 被 Windows 拦截时需要用户核对发行来源，不能由 AI 关闭安全功能绕过。
+
+## 固定项目版本
+
+`init` 创建项目和 `micropixel.lock.json`。已有项目先显式选择版本：
+
+```powershell
+micropixel sdk use 0.16.0 --yes --json
+micropixel sdk status --check --json
+micropixel build --aot-target riscv32-ilp32f --json
+micropixel package --aot-target xtensa --json
+```
+
+示例版本必须替换为发布清单中实际存在的版本。将锁文件与源码一起提交到 Git。
+锁记录精确 SDK、工具链 ID 和 SDK 清单 SHA-256。CLI、Runtime、ABI 随 SDK 一起固定。
+依赖以内容摘要存放在用户缓存，多个项目可同时使用不同版本。
+
+```powershell
+micropixel sdk upgrade --yes --json
+micropixel sdk use 0.16.0 --yes --offline --json
+```
+
+升级先下载并验证全部依赖，再原子替换锁文件；失败保留旧锁。
+回退时依赖已缓存可离线执行。两个操作都不改游戏源码、`app.json` 或应用版本号。
+未知锁格式返回退出码 4，`--yes` 不会接受不兼容格式。
+需要源码迁移时单独处理，并在升级后重新构建、打包和真机测试。
+
+独立 SDK 归档仍允许手动设置编译器。受管理项目默认忽略机器上的编译器覆盖变量。
+确需外部工具链时，先锁定版本，再显式启用：
+
+```powershell
+micropixel sdk use 0.16.0 --external-toolchain --yes --json
+```
+
+外部模式必须提供 `WASI_SDK_PATH`、`WAMRC`、`XTENSA_WAMRC`，结果标记 `external`，不能视为已验证的固定工具链。
+再次 `sdk use <版本> --yes` 恢复受管理工具链。
+
+## 新版检查
+
+- `sdk status --check` 主动检查；`build`、`run` 使用一天内缓存。
+- `package` 和 `publish` 使用五分钟内缓存，每次结果包含版本状态。
+- `--offline` 不联网，返回 `offline` 和缓存时间；没有缓存时候选版本为空。
+- 网络失败返回 `unavailable` 提醒，不阻止依赖完整的旧项目构建或发布。
+- 只有比当前版本新的稳定 SDK 才提示升级。安装管理组件更新使用独立入口 `update --check` / `update --yes`。
+
+日常人类提醒按项目和候选版本去重；JSON 始终包含当前检查状态。
+性能提醒只有发布元数据同时提供描述、适用设备、所需固件和证据链接时才出现。
+“最新版一定更快”不属于 SDK 承诺。
+
+## 发布与验收
+
+源码锁见 [toolchain-sources.json](../../tools/windows/toolchain-sources.json)，
+内置运行时锁见 [runtime-sources.json](../../tools/windows/runtime-sources.json)。
+[统一 SDK 打包器](../../tools/build_sdk_release.py) 为网站与 GitHub 生成同一确定性归档。
+已发布的同版本文件禁止覆盖。
+
+Windows 验收使用 [W01–W19 清单](windows-acceptance.zh-CN.md)。稳定版必须通过自动验证、
+Windows 10 人工验收、两个设备架构实际运行和代码签名；当前 CI 运行于 Windows Server，不能代替 Windows 10 验收。
+
+AI 安装与使用契约见 [SDK AI 指南](../../guest/sdk/AI.md)。

--- a/guest/sdk/AI.md
+++ b/guest/sdk/AI.md
@@ -1,0 +1,94 @@
+# AI 使用 MicroPixel SDK
+
+本文描述 Windows 安装管理组件的 Preview 接口；仅下载独立 SDK 0.15.6 不会获得 setup、doctor 或版本锁管理。
+先读取对应 Release 的安装元数据，不能猜测最新版本或使用仓库混合的 Latest Release。
+
+## 安装
+
+安装必须有用户安装 SDK 的明确意图。下载清单包含 `version`、`architecture`、`url`、`size_bytes` 和 `sha256`。
+以下 PowerShell 示例中的 `$metadataUrl` 必须是已发布 Release 所提供的安装清单 HTTPS 地址：
+
+```powershell
+$metadataUrl = 'https://github.com/78/micropixel/releases/download/sdk-v<VERSION>/windows-installer.json'
+$meta = Invoke-RestMethod -Uri $metadataUrl
+[Console]::OutputEncoding = [Text.UTF8Encoding]::new($false)
+$OutputEncoding = [Console]::OutputEncoding
+if (([Uri]$meta.url).Scheme -ne 'https') { throw 'HTTPS download required' }
+if ($meta.architecture -ne 'windows-x64') { throw 'Unsupported architecture' }
+$installer = Join-Path $env:TEMP 'micropixel-setup.exe'
+Invoke-WebRequest -UseBasicParsing -Uri $meta.url -OutFile $installer
+if ((Get-Item $installer).Length -ne $meta.size_bytes) { throw 'Size mismatch' }
+if ((Get-FileHash $installer -Algorithm SHA256).Hash.ToLowerInvariant() -ne $meta.sha256) { throw 'SHA-256 mismatch' }
+$log = Join-Path $env:TEMP 'micropixel-install.log'
+$p = Start-Process -FilePath $installer -ArgumentList "/VERYSILENT /SUPPRESSMSGBOXES /SP- /NORESTART /LOG=`"$log`"" -Wait -PassThru
+if ($p.ExitCode -ne 0) { throw "Installer failed: $($p.ExitCode)" }
+$mp = "$env:LOCALAPPDATA\MicroPixel\bin\micropixel.exe"
+$setup = & $mp setup --yes --json | ConvertFrom-Json
+if ($LASTEXITCODE -ne 0 -or -not $setup.ok) { throw 'Environment preparation failed; see stderr' }
+$doctor = & $mp doctor --json | ConvertFrom-Json
+if ($LASTEXITCODE -ne 0 -or -not $doctor.ok -or -not $doctor.result.ready) { throw 'Environment is not ready' }
+```
+
+等待安装进程退出后才检查环境。不要假设当前终端 PATH 已刷新，不需要重启电脑。
+不要禁用 SmartScreen、防病毒软件或证书验证；被系统拦截时向用户报告需要人工操作。
+依赖下载失败时重新执行 setup，不能把安装器退出码当作编译环境就绪的证据。
+
+## 日常流程
+
+在项目目录执行：
+
+```text
+micropixel doctor --json
+micropixel sdk status --check --json
+micropixel build --json
+micropixel package --json
+micropixel publish --dry-run --json
+```
+
+新项目使用 `micropixel init <目录> --app-id <标识> --title <名称> --json`。
+已有未锁定项目须先选择清单中的具体版本 `sdk use <版本> --yes --json`。
+仅在用户要求运行到设备时执行 `run --no-follow --json`；持续日志跟随单独进行。
+两台设备连接时显式指定已确认的端口，不猜测设备。
+
+上传商店需要用户发布意图；`publish --dry-run` 只做预检。
+安装 SDK、升级项目、运行设备和上传商店是不同操作，`--yes` 不是对其他操作的授权。
+收到新版提醒不会自动升级。已获升级授权后使用 `sdk upgrade --yes --json`，
+重新编译、打包并测试；源码迁移单独处理。回退使用 `sdk use <旧版本> --yes --offline --json`。
+
+## 机器输出
+
+有限命令的 stdout 是一个最终 JSON 对象；进度、编译器诊断和运行日志在 stderr。
+不要把 stderr 合并进 JSON 输入。结构如下：
+
+```json
+{
+  "schema_version": 1,
+  "ok": true,
+  "code": "ok",
+  "result": {
+    "sdk_version": "0.16.0",
+    "toolchain_id": "windows-x64-<toolchain-digest>",
+    "artifacts": [],
+    "version_status": null
+  },
+  "error": null,
+  "warnings": []
+}
+```
+
+结果字段随命令变化。构建产物记录路径、类型、目标架构；版本状态包含当前版本、候选版本、
+检查状态、时间、发布说明和下一步命令。提醒去重不影响 JSON。
+
+| 退出码 | 含义 | AI 处理 |
+|---|---|---|
+| 0 | 操作成功（可能有新版提醒） | 检查结果及 warnings |
+| 1 | 执行失败 | 根据 error 和 stderr 诊断 |
+| 2 | 参数错误 | 修正命令，不重复盲试 |
+| 3 | 缺少输入或显式选择 | 补充当前操作所需输入 |
+| 4 | 环境或兼容性阻塞 | 准备依赖或报告不兼容，不绕过锁格式 |
+
+`--offline` 明确禁止联网检查，并保留缓存时间；缓存缺失不是“已经最新”。
+`run --json` 必须配合 `--no-follow`，无限日志流不属于最终 JSON 协议。
+
+验收与脱敏报告见 [Windows 验收](https://github.com/78/micropixel/blob/main/docs/development/windows-acceptance.zh-CN.md)。
+辅助脚本不上传数据，不操作设备；上传报告前人工检查备注中没有用户名路径、设备身份或凭据。

--- a/guest/sdk/README.md
+++ b/guest/sdk/README.md
@@ -300,3 +300,5 @@ Network、Camera 和网络资源加载尚未定义公开接口。
 [conformance](../tests/conformance/)。
 
 Mode7Plane、Span 与 surface 纹理的开发步骤见 [图形开发指南](GRAPHICS.md)。
+
+Windows Preview 的安装管理与结构化命令见 [AI 使用指南](AI.md)。

--- a/tools/manager/launch.py
+++ b/tools/manager/launch.py
@@ -8,10 +8,11 @@ from pathlib import Path
 
 def main():
     initial = Path(__file__).resolve().parent
-    root = Path(os.environ.get('MICROPIXEL_HOME', initial.parent.parent))
+    activating = len(sys.argv) in (2, 3) and sys.argv[1] == '--activate-manager'
+    root = Path(sys.argv[2]) if activating and len(sys.argv) == 3 else Path(os.environ.get('MICROPIXEL_HOME', initial.parent.parent))
     os.environ['MICROPIXEL_HOME'] = str(root)
     pointer = root / 'current.json'
-    if sys.argv[1:] == ['--activate-manager']:
+    if activating:
         from micropixel_manager import atomic_json, install_lock
         with install_lock(root):
             atomic_json(pointer, {'directory': str(initial)})

--- a/tools/micropixel
+++ b/tools/micropixel
@@ -26,7 +26,7 @@ from pathlib import Path
 from typing import Any, Callable, TextIO
 
 
-VERSION = "0.15.6"
+VERSION = "0.16.0"
 MINIMUM_FIRMWARE_VERSION = "0.4.0"
 BUNDLE_MAGIC = b"MPXBNDL\0"
 BUNDLE_HEADER_SIZE = 128

--- a/tools/windows/build_installer.py
+++ b/tools/windows/build_installer.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Build the unsigned Preview installer. Signing/stable promotion is a separate gate."""
+import argparse
+import json
+import re
+import subprocess
+import sys
+import urllib.request
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / 'tools'))
+from windows.release_metadata import asset
+from manager.micropixel_manager import file_digest
+
+
+def run(*args):
+    subprocess.run([str(a) for a in args], check=True)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--output', required=True, type=Path)
+    parser.add_argument('--repository', default='78/micropixel')
+    args = parser.parse_args()
+    output = args.output.resolve()
+    output.mkdir(parents=True, exist_ok=True)
+    version = re.search(r'^VERSION = "([0-9.]+)"$', (ROOT / 'tools/micropixel').read_text(), re.M)[1]
+    run(sys.executable, ROOT / 'tools/windows/build_manager.py', '--output', output / 'runtime')
+    build = json.loads((output / 'runtime/manager-build.json').read_text())
+    build_id = build['build_id']
+    generated = output / 'generated'
+    generated.mkdir(exist_ok=True)
+    (generated / 'bootstrap_config.h').write_text('#define BOOTSTRAP_ID L"' + build_id + '"\n')
+    launcher = output / 'runtime/micropixel.exe'
+    run('cl', '/nologo', '/O2', '/MT', '/W4', '/WX', '/std:c11', '/DUNICODE', '/D_UNICODE',
+        '/I' + str(generated), '/Fo' + str(generated / 'launcher.obj'),
+        '/Fe' + str(launcher), ROOT / 'tools/windows/launcher.c')
+    spec = json.loads((ROOT / 'tools/windows/installer-sources.json').read_text())['inno_setup']
+    compiler_installer = output / 'inno-setup.exe'
+    urllib.request.urlretrieve(spec['url'], compiler_installer)
+    if compiler_installer.stat().st_size != spec['size_bytes'] or file_digest(compiler_installer) != spec['sha256']:
+        raise SystemExit('Inno Setup checksum mismatch')
+    compiler = output / 'inno'
+    run(compiler_installer, '/VERYSILENT', '/SUPPRESSMSGBOXES', '/SP-', '/NORESTART', '/NOICONS', '/DIR=' + str(compiler))
+    run(compiler / 'ISCC.exe', '/DSdkVersion=' + version, '/DManagerBuild=' + build_id,
+        '/DPayloadDir=' + str(output / 'runtime'), '/DReleaseDir=' + str(output), ROOT / 'tools/windows/micropixel.iss')
+    installer = output / f'micropixel-setup-{version}-windows-x64-preview.exe'
+    metadata = asset(installer, f'https://github.com/{args.repository}/releases/download/sdk-v{version}', '')
+    metadata.pop('root')
+    metadata.update(schema_version=1, version=version, architecture='windows-x64', preview=True,
+                    manager_version=build['version'], manager_build_id=build_id)
+    (output / 'windows-installer.json').write_text(json.dumps(metadata, indent=2) + '\n')
+    print(json.dumps(metadata))
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/windows/collect_acceptance.ps1
+++ b/tools/windows/collect_acceptance.ps1
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+# Read-only environment collection. Never installs, upgrades, flashes or uploads.
+[CmdletBinding()]
+param(
+    [string]$MicroPixel = "$env:LOCALAPPDATA\MicroPixel\bin\micropixel.exe",
+    [string]$Output = "$env:TEMP\micropixel-acceptance.json"
+)
+$ErrorActionPreference = 'Stop'
+$report = [ordered]@{
+    schema_version = 1
+    collected_at = (Get-Date).ToUniversalTime().ToString('o')
+    os = [ordered]@{
+        version = [Environment]::OSVersion.Version.ToString()
+        is_64_bit = [Environment]::Is64BitOperatingSystem
+        powershell = $PSVersionTable.PSVersion.ToString()
+    }
+    launcher_found = (Test-Path -LiteralPath $MicroPixel -PathType Leaf)
+    checks = @()
+    manual_results = @()
+}
+# Keep only reviewed fields. Raw stdout/stderr, paths and device data are never saved.
+function Read-Check([string]$Name, [string[]]$Arguments) {
+    $status = [ordered]@{ name = $Name; exit_code = $null; json_valid = $false }
+    try {
+        $raw = & $MicroPixel @Arguments 2>$null
+        $status.exit_code = $LASTEXITCODE
+        $value = ($raw -join "`n") | ConvertFrom-Json -ErrorAction Stop
+        $status.json_valid = $true
+        if ($null -ne $value.schema_version) { $status.schema_version = $value.schema_version }
+        if ($null -ne $value.ok) { $status.ok = [bool]$value.ok }
+        if ($null -ne $value.result.ready) { $status.ready = [bool]$value.result.ready }
+        foreach ($key in @('sdk_version', 'toolchain_id', 'manager_version', 'manager_build_id', 'python_version', 'pyserial_version', 'wasi_sdk_version')) {
+            $entry = $value.result.$key
+            # Version/build identifiers only; never persist arbitrary diagnostic strings.
+            if ($entry -is [string] -and $entry -match '^[a-zA-Z0-9._+-]{1,96}$') { $status[$key] = $entry }
+        }
+        $status.tools = @{}
+        foreach ($tool in @('clang', 'riscv', 'xtensa')) {
+            $entry = $value.result.tools.$tool
+            if ($entry -is [string] -and $entry -match '\b[0-9]+\.[0-9]+(?:\.[0-9]+){0,2}\b') { $status.tools[$tool] = $Matches[0] }
+        }
+    } catch {
+        $status.error = 'check_failed_or_invalid_json'
+    }
+    return $status
+}
+if ($report.launcher_found) {
+    $report.checks += Read-Check 'doctor' @('doctor', '--offline', '--json')
+    $report.checks += Read-Check 'sdk_status' @('sdk', 'status', '--offline', '--json')
+}
+1..19 | ForEach-Object {
+    $report.manual_results += [ordered]@{ id = ('W{0:D2}' -f $_); status = 'not_run'; notes = '' }
+}
+$report | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $Output -Encoding UTF8
+Write-Host "Local acceptance report written. No logs or device identifiers were collected or uploaded."
+if (-not $report.launcher_found) { exit 4 }
+if (@($report.checks | Where-Object { $_.exit_code -ne 0 -or -not $_.json_valid }).Count) { exit 4 }

--- a/tools/windows/installer-sources.json
+++ b/tools/windows/installer-sources.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": 1,
+  "inno_setup": {
+    "version": "6.7.3",
+    "url": "https://github.com/jrsoftware/issrc/releases/download/is-6_7_3/innosetup-6.7.3.exe",
+    "size_bytes": 10592232,
+    "sha256": "9c73c3bae7ed48d44112a0f48e66742c00090bdb5bef71d9d3c056c66e97b732"
+  }
+}

--- a/tools/windows/launcher.c
+++ b/tools/windows/launcher.c
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Forward the original command line without invoking cmd.exe or PowerShell.
+#define WIN32_LEAN_AND_MEAN
+#include <stdio.h>
+#include <wchar.h>
+#include <windows.h>
+
+#include "bootstrap_config.h"
+
+// Process-owned buffers are bounded by the Windows command-line/path limit.
+static wchar_t module_path[32768], python_path[32768], script_path[32768], command[32768];
+
+static BOOL WINAPI control_handler(DWORD event) { return event == CTRL_C_EVENT || event == CTRL_BREAK_EVENT; }
+
+int wmain(int argc, wchar_t** argv) {
+    int json_mode = 0;
+    for (int i = 1; i < argc && wcscmp(argv[i], L"--") != 0; ++i)
+        if (wcscmp(argv[i], L"--json") == 0) json_mode = 1;
+    DWORD length = GetModuleFileNameW(NULL, module_path, 32768);
+    wchar_t* separator = wcsrchr(module_path, L'\\');
+    if (length == 0 || length >= 32768 || separator == NULL) goto failed;
+    *separator = L'\0';
+    if (_snwprintf_s(python_path, 32768, _TRUNCATE, L"%ls\\..\\versions\\%ls\\python\\python.exe", module_path,
+                     BOOTSTRAP_ID) < 0 ||
+        _snwprintf_s(script_path, 32768, _TRUNCATE, L"%ls\\..\\versions\\%ls\\launch.py", module_path, BOOTSTRAP_ID) <
+            0)
+        goto failed;
+    const wchar_t* rest = GetCommandLineW();
+    if (*rest == L'"') {
+        ++rest;
+        while (*rest && *rest != L'"') ++rest;
+        if (*rest) ++rest;
+    } else {
+        while (*rest && *rest != L' ' && *rest != L'\t') ++rest;
+    }
+    while (*rest == L' ' || *rest == L'\t') ++rest;
+    if (_snwprintf_s(command, 32768, _TRUNCATE, L"\"%ls\" -I -X utf8 \"%ls\" %ls", python_path, script_path, rest) < 0)
+        goto failed;
+    STARTUPINFOW startup = {0};
+    PROCESS_INFORMATION process = {0};
+    startup.cb = sizeof(startup);
+    startup.dwFlags = STARTF_USESTDHANDLES;
+    startup.hStdInput = GetStdHandle(STD_INPUT_HANDLE);
+    startup.hStdOutput = GetStdHandle(STD_OUTPUT_HANDLE);
+    startup.hStdError = GetStdHandle(STD_ERROR_HANDLE);
+    SetConsoleCtrlHandler(control_handler, TRUE);
+    if (!CreateProcessW(python_path, command, NULL, NULL, TRUE, 0, NULL, NULL, &startup, &process)) goto failed;
+    CloseHandle(process.hThread);
+    WaitForSingleObject(process.hProcess, INFINITE);
+    DWORD exit_code = 1;
+    GetExitCodeProcess(process.hProcess, &exit_code);
+    CloseHandle(process.hProcess);
+    return exit_code <= 4 ? (int)exit_code : 1;
+failed:
+    fprintf(stderr,
+            "MicroPixel launcher could not start the installed runtime (Windows error %lu). Reinstall MicroPixel.\n",
+            GetLastError());
+    if (json_mode)
+        puts(
+            "{\"schema_version\":1,\"ok\":false,\"code\":\"bootstrap_failed\",\"result\":{},\"error\":{\"code\":"
+            "\"bootstrap_failed\",\"message\":\"Unable to start the installed runtime; reinstall "
+            "MicroPixel\"},\"warnings\":[]}");
+    return 4;
+}

--- a/tools/windows/micropixel.iss
+++ b/tools/windows/micropixel.iss
@@ -1,0 +1,198 @@
+; SPDX-License-Identifier: Apache-2.0
+#ifndef SdkVersion
+  #error SdkVersion is required
+#endif
+#ifndef ManagerBuild
+  #error ManagerBuild is required
+#endif
+#ifndef PayloadDir
+  #error PayloadDir is required
+#endif
+#ifndef ReleaseDir
+  #error ReleaseDir is required
+#endif
+[Setup]
+AppId=MicroPixel.SDK
+AppName=MicroPixel SDK Preview
+AppVersion={#SdkVersion}
+AppPublisher=MicroPixel
+AppPublisherURL=https://micropixel.ai
+DefaultDirName={localappdata}\MicroPixel
+DisableDirPage=yes
+UsePreviousAppDir=no
+PrivilegesRequired=lowest
+ArchitecturesAllowed=x64os
+ArchitecturesInstallIn64BitMode=x64os
+MinVersion=10.0.19045
+WizardStyle=modern
+ChangesEnvironment=yes
+CloseApplications=no
+RestartApplications=no
+AlwaysRestart=no
+RestartIfNeededByRun=no
+Compression=lzma2/normal
+SolidCompression=yes
+OutputDir={#ReleaseDir}
+OutputBaseFilename=micropixel-setup-{#SdkVersion}-windows-x64-preview
+UninstallDisplayName=MicroPixel SDK Preview
+LicenseFile=..\..\LICENSE
+
+[Files]
+Source: "{#PayloadDir}\{#ManagerBuild}\*"; DestDir: "{app}\versions\{#ManagerBuild}"; Flags: recursesubdirs createallsubdirs ignoreversion onlyifdoesntexist
+Source: "{#PayloadDir}\micropixel.exe"; DestDir: "{app}\bin"; Flags: ignoreversion
+Source: "..\..\docs\development\windows-sdk.zh-CN.md"; DestDir: "{app}\docs"; Flags: ignoreversion
+Source: "..\..\guest\sdk\AI.md"; DestDir: "{app}\docs"; Flags: ignoreversion
+
+[Icons]
+Name: "{userprograms}\MicroPixel SDK\Developer command prompt"; Filename: "{cmd}"; Parameters: "/K """"{app}\bin\micropixel.exe"" doctor"""; WorkingDir: "{userdocs}"
+Name: "{userprograms}\MicroPixel SDK\Windows guide"; Filename: "https://github.com/78/micropixel/blob/sdk-v{#SdkVersion}/docs/development/windows-sdk.zh-CN.md"
+
+[Registry]
+Root: HKCU; Subkey: "Software\MicroPixel"; Flags: uninsdeletekeyifempty
+
+[Code]
+var
+  Prepared: Boolean;
+  RetryButton: TNewButton;
+  PurgeCache: Boolean;
+
+function NormalPath(Value: String): String;
+begin
+  Result := Lowercase(Trim(Value));
+  if (Length(Result) > 1) and (Result[1] = '"') and (Result[Length(Result)] = '"') then
+    Result := Copy(Result, 2, Length(Result) - 2);
+  StringChangeEx(Result, '/', '\', True);
+  StringChangeEx(Result, '%localappdata%', Lowercase(ExpandConstant('{localappdata}')), True);
+  while (Length(Result) > 0) and (Result[Length(Result)] = '\') do
+    Delete(Result, Length(Result), 1);
+end;
+
+function FilterPath(Value: String; var Found: Boolean): String;
+var Part: String; Position: Integer; Last, First: Boolean;
+begin
+  Result := ''; Found := False; First := True;
+  repeat
+    Position := Pos(';', Value);
+    Last := Position = 0;
+    if Last then begin Part := Value; Value := ''; end
+    else begin Part := Copy(Value, 1, Position - 1); Delete(Value, 1, Position); end;
+    if NormalPath(Part) = NormalPath(ExpandConstant('{app}\bin')) then Found := True
+    else begin
+      if not First then Result := Result + ';';
+      Result := Result + Part;
+      First := False;
+    end;
+  until Last;
+end;
+
+procedure AddUserPath;
+var Value, Filtered: String; Found: Boolean;
+begin
+  RegQueryStringValue(HKCU, 'Environment', 'Path', Value);
+  Filtered := FilterPath(Value, Found);
+  if not Found then begin
+    if Value <> '' then Value := Value + ';';
+    Value := Value + ExpandConstant('{app}\bin');
+    if not RegWriteExpandStringValue(HKCU, 'Environment', 'Path', Value) then
+      RaiseException('Could not update the current user PATH.');
+    RegWriteStringValue(HKCU, 'Software\MicroPixel', 'OwnsPathEntry', '1');
+  end;
+end;
+
+procedure RemoveUserPath;
+var Value, Owner: String; Found: Boolean;
+begin
+  if RegQueryStringValue(HKCU, 'Software\MicroPixel', 'OwnsPathEntry', Owner) and (Owner = '1') then begin
+    RegQueryStringValue(HKCU, 'Environment', 'Path', Value);
+    Value := FilterPath(Value, Found);
+    if Found then RegWriteExpandStringValue(HKCU, 'Environment', 'Path', Value);
+    RegDeleteValue(HKCU, 'Software\MicroPixel', 'OwnsPathEntry');
+  end;
+end;
+
+function RunManager(Arguments: String; Show: Integer): Boolean;
+var Code: Integer;
+begin
+  Result := Exec(ExpandConstant('{app}\bin\micropixel.exe'), Arguments,
+    ExpandConstant('{app}'), Show, ewWaitUntilTerminated, Code) and (Code = 0);
+end;
+
+procedure PrepareEnvironment;
+begin
+  WizardForm.StatusLabel.Caption := 'Preparing SDK and toolchains. Download progress is shown in the console.';
+  Prepared := RunManager('setup --version {#SdkVersion} --yes --json', SW_SHOW);
+  if Prepared then Prepared := RunManager('doctor --json', SW_SHOW);
+  if Prepared then WizardForm.FinishedLabel.Caption := 'MicroPixel development environment is ready. Open a new terminal and run micropixel doctor --json.'
+  else WizardForm.FinishedLabel.Caption := 'Environment is not ready. Check the connection and retry, or run micropixel setup --yes --json followed by micropixel doctor --json. Installer success alone does not mean the toolchain is ready.';
+  RetryButton.Visible := not Prepared;
+end;
+
+procedure RetryPreparation(Sender: TObject);
+begin
+  RetryButton.Enabled := False;
+  try PrepareEnvironment; finally RetryButton.Enabled := True; end;
+end;
+
+procedure InitializeWizard;
+begin
+  Prepared := False;
+  WizardForm.FinishedLabel.Height := ScaleY(130);
+  RetryButton := TNewButton.Create(WizardForm);
+  RetryButton.Parent := WizardForm.FinishedPage;
+  RetryButton.Caption := 'Retry tool preparation';
+  RetryButton.Width := ScaleX(180);
+  RetryButton.Left := WizardForm.FinishedLabel.Left;
+  RetryButton.Top := WizardForm.FinishedLabel.Top + WizardForm.FinishedLabel.Height + ScaleY(16);
+  RetryButton.OnClick := @RetryPreparation;
+  RetryButton.Visible := False;
+end;
+
+procedure CurStepChanged(CurStep: TSetupStep);
+var Code: Integer;
+begin
+  if CurStep = ssPostInstall then begin
+    AddUserPath;
+    if not Exec(ExpandConstant('{app}\versions\{#ManagerBuild}\python\python.exe'),
+      '-I -X utf8 "' + ExpandConstant('{app}\versions\{#ManagerBuild}\launch.py') + '" --activate-manager "' + ExpandConstant('{app}') + '"',
+      ExpandConstant('{app}'), SW_HIDE, ewWaitUntilTerminated, Code) or (Code <> 0) then
+      RaiseException('Could not activate the manager. Existing cached SDKs were preserved.');
+    if not WizardSilent then PrepareEnvironment;
+  end;
+end;
+
+procedure CurPageChanged(CurPageID: Integer);
+begin
+  if (CurPageID = wpFinished) and not WizardSilent then begin
+    if Prepared then WizardForm.FinishedLabel.Caption := 'MicroPixel development environment is ready. Open a new terminal and run micropixel doctor --json.'
+    else WizardForm.FinishedLabel.Caption := 'Environment is not ready. Retry tool preparation, or run micropixel setup --yes --json and micropixel doctor --json. Installer success alone does not mean the toolchain is ready.';
+    RetryButton.Visible := not Prepared;
+  end;
+end;
+
+function InitializeUninstall: Boolean;
+var Index: Integer;
+begin
+  PurgeCache := False;
+  for Index := 1 to ParamCount do
+    if CompareText(ParamStr(Index), '/PURGECACHE') = 0 then PurgeCache := True;
+  if not UninstallSilent then
+    PurgeCache := MsgBox('Also remove downloaded SDK/toolchain caches? Your game projects are preserved.', mbConfirmation, MB_YESNO or MB_DEFBUTTON2) = IDYES;
+  Result := True;
+end;
+
+procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
+begin
+  if CurUninstallStep = usPostUninstall then begin
+    RemoveUserPath;
+    DeleteFile(ExpandConstant('{app}\current.json'));
+    if PurgeCache then begin
+      DelTree(ExpandConstant('{app}\downloads'), True, True, True);
+      DelTree(ExpandConstant('{app}\packages'), True, True, True);
+      DelTree(ExpandConstant('{app}\environments'), True, True, True);
+      DelTree(ExpandConstant('{app}\manifests'), True, True, True);
+      DelTree(ExpandConstant('{app}\notices'), True, True, True);
+      DeleteFile(ExpandConstant('{app}\default.json'));
+      DeleteFile(ExpandConstant('{app}\index-cache.json'));
+    end;
+  end;
+end;

--- a/tools/windows/test_installer.ps1
+++ b/tools/windows/test_installer.ps1
@@ -9,10 +9,18 @@ $project = Join-Path $env:RUNNER_TEMP '中文 游戏 & project'
 New-Item -ItemType Directory -Force -Path $project | Out-Null
 Set-Content -LiteralPath (Join-Path $project 'keep.txt') -Value 'project must survive uninstall'
 function Execute-Installer([string]$File, [string]$Extra = '') {
-    $p = Start-Process -FilePath $File -ArgumentList "/VERYSILENT /SUPPRESSMSGBOXES /SP- /NORESTART $Extra" -PassThru
-    $p | Wait-Process -Timeout 120
-    $p.Refresh()
-    if ($p.ExitCode -ne 0) { throw "Installer/uninstaller exit: $($p.ExitCode)" }
+    # Inno uninstall can hand off to a temporary child executable. -Wait waits
+    # for the whole process tree; Wait-Process only waited for the bootstrap.
+    $job = Start-Job -ArgumentList $File, $Extra -ScriptBlock {
+        param($Executable, $Options)
+        $p = Start-Process -FilePath $Executable -ArgumentList "/VERYSILENT /SUPPRESSMSGBOXES /SP- /NORESTART $Options" -PassThru -Wait
+        $p.ExitCode
+    }
+    try {
+        if (-not (Wait-Job $job -Timeout 120)) { throw 'Installer process tree timed out' }
+        $code = Receive-Job $job -ErrorAction Stop
+        if ($code -ne 0) { throw "Installer/uninstaller exit: $code" }
+    } finally { Remove-Job $job -Force }
 }
 function Assert-PathCount([int]$Expected, [string]$Stage) {
     $bin = (Join-Path $root 'bin').ToLowerInvariant()

--- a/tools/windows/test_installer.ps1
+++ b/tools/windows/test_installer.ps1
@@ -1,0 +1,45 @@
+# Exercise silent install/uninstall without a prepared SDK; no device or network actions.
+[CmdletBinding()]
+param([Parameter(Mandatory=$true)][string]$Installer)
+$ErrorActionPreference = 'Stop'
+[Console]::OutputEncoding = [Text.UTF8Encoding]::new($false)
+$root = Join-Path $env:LOCALAPPDATA 'MicroPixel'
+$launcher = Join-Path $root 'bin\micropixel.exe'
+$project = Join-Path $env:RUNNER_TEMP '中文 游戏 & project'
+New-Item -ItemType Directory -Force -Path $project | Out-Null
+Set-Content -LiteralPath (Join-Path $project 'keep.txt') -Value 'project must survive uninstall'
+function Execute-Installer([string]$File, [string]$Extra = '') {
+    $p = Start-Process -FilePath $File -ArgumentList "/VERYSILENT /SUPPRESSMSGBOXES /SP- /NORESTART $Extra" -PassThru
+    $p | Wait-Process -Timeout 120
+    $p.Refresh()
+    if ($p.ExitCode -ne 0) { throw "Installer/uninstaller exit: $($p.ExitCode)" }
+}
+function Assert-PathCount([int]$Expected) {
+    $bin = (Join-Path $root 'bin').ToLowerInvariant()
+    $paths = @(([Environment]::GetEnvironmentVariable('Path', 'User') -split ';') | Where-Object { $_.Trim().TrimEnd('\').ToLowerInvariant() -eq $bin })
+    if ($paths.Count -ne $Expected) { throw 'User PATH registration is incorrect' }
+}
+Execute-Installer $Installer
+$probe = & $launcher manager-version --json | ConvertFrom-Json
+if ($LASTEXITCODE -ne 0 -or -not $probe.ok -or $probe.result.python_version -ne '3.13.12' -or $probe.result.pyserial_version -ne '3.5') { throw 'Native launcher or embedded runtime failed' }
+$doctor = & $launcher doctor --offline --json | ConvertFrom-Json
+if ($LASTEXITCODE -ne 4 -or $doctor.ok) { throw 'Installer incorrectly reported an unprepared SDK as ready' }
+Assert-PathCount 1
+New-Item -ItemType Directory -Force -Path (Join-Path $root 'packages') | Out-Null
+$marker = Join-Path $root 'packages\cache-marker.txt'
+Set-Content -LiteralPath $marker -Value 'retained cache'
+$uninstaller = @(Get-ChildItem -LiteralPath $root -Filter 'unins*.exe')
+if ($uninstaller.Count -ne 1) { throw 'Expected one uninstaller' }
+Execute-Installer $uninstaller[0].FullName
+Assert-PathCount 0
+if (-not (Test-Path -LiteralPath $marker) -or -not (Test-Path -LiteralPath (Join-Path $project 'keep.txt'))) { throw 'Uninstall removed retained data' }
+Execute-Installer $Installer
+Assert-PathCount 1
+$probe = & $launcher manager-version --json | ConvertFrom-Json
+if ($LASTEXITCODE -ne 0 -or -not $probe.ok) { throw 'Reinstall failed' }
+$uninstaller = @(Get-ChildItem -LiteralPath $root -Filter 'unins*.exe')
+Execute-Installer $uninstaller[0].FullName '/PURGECACHE'
+if (Test-Path -LiteralPath $marker) { throw 'Explicit cache purge was ignored' }
+if (-not (Test-Path -LiteralPath (Join-Path $project 'keep.txt'))) { throw 'Cache purge touched a project' }
+Assert-PathCount 0
+Write-Host 'Silent install, native launcher, truthful doctor, PATH, cache retention and reinstall passed.'

--- a/tools/windows/test_installer.ps1
+++ b/tools/windows/test_installer.ps1
@@ -14,32 +14,35 @@ function Execute-Installer([string]$File, [string]$Extra = '') {
     $p.Refresh()
     if ($p.ExitCode -ne 0) { throw "Installer/uninstaller exit: $($p.ExitCode)" }
 }
-function Assert-PathCount([int]$Expected) {
+function Assert-PathCount([int]$Expected, [string]$Stage) {
     $bin = (Join-Path $root 'bin').ToLowerInvariant()
     $paths = @(([Environment]::GetEnvironmentVariable('Path', 'User') -split ';') | Where-Object { $_.Trim().TrimEnd('\').ToLowerInvariant() -eq $bin })
-    if ($paths.Count -ne $Expected) { throw 'User PATH registration is incorrect' }
+    if ($paths.Count -ne $Expected) {
+        $entries = @(([Environment]::GetEnvironmentVariable('Path', 'User') -split ';') | Where-Object { $_ -like '*MicroPixel*' })
+        throw "User PATH registration is incorrect at $Stage; expected $Expected, got $($paths.Count); MicroPixel entries: $($entries -join ', ')"
+    }
 }
 Execute-Installer $Installer
 $probe = & $launcher manager-version --json | ConvertFrom-Json
 if ($LASTEXITCODE -ne 0 -or -not $probe.ok -or $probe.result.python_version -ne '3.13.12' -or $probe.result.pyserial_version -ne '3.5') { throw 'Native launcher or embedded runtime failed' }
 $doctor = & $launcher doctor --offline --json | ConvertFrom-Json
 if ($LASTEXITCODE -ne 4 -or $doctor.ok) { throw 'Installer incorrectly reported an unprepared SDK as ready' }
-Assert-PathCount 1
+Assert-PathCount 1 'first install'
 New-Item -ItemType Directory -Force -Path (Join-Path $root 'packages') | Out-Null
 $marker = Join-Path $root 'packages\cache-marker.txt'
 Set-Content -LiteralPath $marker -Value 'retained cache'
 $uninstaller = @(Get-ChildItem -LiteralPath $root -Filter 'unins*.exe')
 if ($uninstaller.Count -ne 1) { throw 'Expected one uninstaller' }
 Execute-Installer $uninstaller[0].FullName
-Assert-PathCount 0
+Assert-PathCount 0 'first uninstall'
 if (-not (Test-Path -LiteralPath $marker) -or -not (Test-Path -LiteralPath (Join-Path $project 'keep.txt'))) { throw 'Uninstall removed retained data' }
 Execute-Installer $Installer
-Assert-PathCount 1
+Assert-PathCount 1 'reinstall'
 $probe = & $launcher manager-version --json | ConvertFrom-Json
 if ($LASTEXITCODE -ne 0 -or -not $probe.ok) { throw 'Reinstall failed' }
 $uninstaller = @(Get-ChildItem -LiteralPath $root -Filter 'unins*.exe')
 Execute-Installer $uninstaller[0].FullName '/PURGECACHE'
 if (Test-Path -LiteralPath $marker) { throw 'Explicit cache purge was ignored' }
 if (-not (Test-Path -LiteralPath (Join-Path $project 'keep.txt'))) { throw 'Cache purge touched a project' }
-Assert-PathCount 0
+Assert-PathCount 0 'purge uninstall'
 Write-Host 'Silent install, native launcher, truthful doctor, PATH, cache retention and reinstall passed.'


### PR DESCRIPTION
Build a native launcher and pinned Inno Setup installer with embedded Python, shared setup/doctor, user PATH management, and cache-preserving uninstall. Add user/AI guides and W01–W19 hardware acceptance checklist. Windows CI passed silent install, truthful unprepared doctor, uninstall process-tree waiting, cache retention, reinstall and explicit purge. GUI Windows 10 and physical device acceptance remain required before stable release.