### PR TITLE
feat(sdk): publish verified Windows Preview installers and acceptance kits

### DIFF
--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -2,10 +2,9 @@ name: Verify and publish SDK Preview
 on:
   workflow_dispatch:
   push:
-    branches: ['codex/windows-sdk-preview']
     tags: ['sdk-v*']
   pull_request:
-    paths: ['guest/**', 'tools/micropixel', 'tools/manager/**', 'tools/windows/**', 'tools/build_sdk_release.py', '.github/workflows/sdk-release.yml']
+    paths: ['guest/**', 'tools/micropixel', 'tools/manager/**', 'tools/windows/**', 'tools/build_sdk_release.py', 'tools/build_app_bundle.py', 'tools/generate_localization.py', 'tools/analyze_sfx.py', '.github/workflows/sdk-release.yml']
 permissions:
   contents: write
 concurrency:

--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -1,0 +1,76 @@
+name: Verify and publish SDK Preview
+on:
+  workflow_dispatch:
+  push:
+    branches: ['codex/windows-sdk-preview']
+    tags: ['sdk-v*']
+  pull_request:
+    paths: ['guest/**', 'tools/micropixel', 'tools/manager/**', 'tools/windows/**', 'tools/build_sdk_release.py', '.github/workflows/sdk-release.yml']
+permissions:
+  contents: write
+concurrency:
+  group: sdk-preview-${{ github.ref }}
+  cancel-in-progress: false
+jobs:
+  release:
+    runs-on: windows-2022
+    timeout-minutes: 60
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+      PYTHONUTF8: '1'
+      PYTHONIOENCODING: utf-8
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: '3.13.12'
+      - name: Regression tests
+        run: python -m unittest tools.tests.test_windows_toolchain tools.tests.test_sdk_release tools.tests.test_sdk_manager tools.tests.test_cli_json -v
+      - name: Activate MSVC x64
+        shell: pwsh
+        run: |
+          $vs = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products '*' -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+          $vcvars = Join-Path $vs 'VC\Auxiliary\Build\vcvars64.bat'
+          cmd /c "`"$vcvars`" >nul && set" | ForEach-Object {
+            if ($_ -match '^([^=]+)=(.*)$' -and $Matches[1] -in @('Path', 'INCLUDE', 'LIB', 'LIBPATH', 'VCINSTALLDIR', 'VCToolsInstallDir', 'VCToolsRedistDir', 'VCToolsVersion', 'WindowsSdkDir', 'WindowsSDKVersion')) { "$($Matches[1])=$($Matches[2])" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8 }
+          }
+      - name: Assemble unsigned installer and immutable SDK metadata
+        run: |
+          python tools/windows/build_installer.py --output build/release
+          if ($LASTEXITCODE -ne 0) { throw 'Installer build failed' }
+          python tools/windows/prepare_sdk_release.py --directory build/release
+          if ($LASTEXITCODE -ne 0) { throw 'SDK assembly failed' }
+      - name: Silent installer lifecycle
+        run: |
+          $metadata = Get-Content -Raw build/release/windows-installer.json | ConvertFrom-Json
+          ./tools/windows/test_installer.ps1 -Installer (Join-Path build/release $metadata.name)
+          if ($LASTEXITCODE -ne 0) { throw 'Installer lifecycle failed' }
+          $process = Start-Process -FilePath (Join-Path build/release $metadata.name) -ArgumentList '/VERYSILENT /SUPPRESSMSGBOXES /SP- /NORESTART' -PassThru -Wait
+          if ($process.ExitCode -ne 0) { throw 'Integration install failed' }
+      - name: Installed dual-architecture build and A/B rollback
+        run: python tools/windows/verify_installed_sdk.py --directory build/release
+      - name: Create immutable Draft Release
+        if: startsWith(github.ref, 'refs/tags/sdk-v')
+        run: python tools/windows/publish_sdk.py draft --directory build/release
+      - name: Publish Preview
+        if: startsWith(github.ref, 'refs/tags/sdk-v')
+        run: python tools/windows/publish_sdk.py publish --directory build/release
+      - name: Verify public downloads and fresh installed SDK
+        if: startsWith(github.ref, 'refs/tags/sdk-v')
+        run: python tools/windows/verify_installed_sdk.py --directory build/release --public
+      - name: Promote verified Preview channel
+        if: startsWith(github.ref, 'refs/tags/sdk-v')
+        run: |
+          git config --global credential.helper '!gh auth git-credential'
+          python tools/windows/publish_sdk.py promote --directory build/release
+      - name: Preserve verification evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: sdk-preview-verification
+          path: |
+            build/release/*verification.json
+            build/release/windows-installer.json
+            build/release/release-notes.json
+          if-no-files-found: ignore

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -1,10 +1,6 @@
 name: Windows Preview installer
 on:
   workflow_dispatch:
-  push:
-    branches: ['codex/windows-sdk-installer']
-  pull_request:
-    paths: ['tools/windows/**', 'tools/manager/**', 'tools/micropixel', '.github/workflows/windows-installer.yml']
 permissions:
   contents: read
 concurrency:

--- a/.github/workflows/windows-sdk-tests.yml
+++ b/.github/workflows/windows-sdk-tests.yml
@@ -1,8 +1,6 @@
 name: SDK manager and archive tests
 on:
   workflow_dispatch:
-  push:
-    branches: ['codex/sdk-version-manager', 'codex/windows-sdk-installer', 'codex/windows-sdk-release', 'codex/windows-toolchain-release', 'codex/windows-sdk-runtime']
   pull_request:
     paths: ['tools/**', 'guest/sdk/**', '.github/workflows/windows-sdk-tests.yml']
 permissions:

--- a/.github/workflows/windows-toolchain.yml
+++ b/.github/workflows/windows-toolchain.yml
@@ -1,12 +1,11 @@
 name: Windows toolchain verification
 on:
   workflow_dispatch:
-  push:
-    branches: ['codex/windows-sdk-bootstrap']
   pull_request:
     paths:
-      - 'tools/**'
-      - 'guest/**'
+      - 'tools/windows/build_toolchain.py'
+      - 'tools/windows/toolchain-sources.json'
+      - 'tools/windows/verify_build.py'
       - '.github/workflows/windows-toolchain.yml'
       - 'firmware/espressif/components/wasm-micro-runtime'
 permissions:
@@ -16,6 +15,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   compile:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: windows-2022
     timeout-minutes: 350
     strategy:
@@ -40,7 +40,7 @@ jobs:
           $vs = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products '*' -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
           $vcvars = Join-Path $vs 'VC\Auxiliary\Build\vcvars64.bat'
           cmd /c "`"$vcvars`" >nul && set" | ForEach-Object {
-            if ($_ -match '^([^=]+)=(.*)$') { "$($Matches[1])=$($Matches[2])" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8 }
+            if ($_ -match '^([^=]+)=(.*)$' -and $Matches[1] -in @('Path', 'INCLUDE', 'LIB', 'LIBPATH', 'VCINSTALLDIR', 'VCToolsInstallDir', 'VCToolsRedistDir', 'VCToolsVersion', 'WindowsSdkDir', 'WindowsSDKVersion')) { "$($Matches[1])=$($Matches[2])" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8 }
           }
       - name: Cache exact LLVM build
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,9 @@
   共用的 Xtensa AOT、RGB565 路径、内存与硬件约束，以及当前验收方法；
 - [Host 构建与烧录指南](development/flashing.zh-CN.md)：P4 产品与 S31/S3 preview 的环境、设备识别、烧录和排错；
 - [USB 本地控制协议](design/usb-local-control.zh-CN.md)：CLI 本地 App 管理、日志、截图、输入和安全边界；
+- [Windows SDK 安装与版本管理](development/windows-sdk.zh-CN.md)；
+- [Windows SDK 真机验收](development/windows-acceptance.zh-CN.md)：W01–W19 与 A/B 实验；
+- [SDK 与 Windows 发布](development/sdk-release.zh-CN.md)：不可变产物、专用更新索引及稳定版门槛；
 - [音效清单模板](development/game-sfx.template.json)：新游戏的起始配置。
 
 与代码一起演进的组件级说明放在源码附近：
@@ -47,7 +50,3 @@ Espressif 官方支持渠道取得。其他板卡和器件信息同样只引用�
 
 新的硬件引用只记录官方来源、型号、版本和必要的校验值；除非再分发许可明确允许，
 不把第三方二进制文档纳入版本控制。
-
-- [Windows SDK 真机验收](development/windows-acceptance.zh-CN.md)：安装、AI 命令、更新回退与双架构设备测试清单（安装器 Preview 就绪后执行）。
-
-- [Windows SDK 安装与版本管理](development/windows-sdk.zh-CN.md)

--- a/docs/development/sdk-release.zh-CN.md
+++ b/docs/development/sdk-release.zh-CN.md
@@ -1,0 +1,53 @@
+# SDK 与 Windows Preview 发布
+
+SDK、Windows 管理组件与工具链分别保留不可变的版本产物。SDK 使用 `sdk-v<版本>`，
+工具链使用 `toolchain-windows-x64-<摘要>`；更新检查读取 `sdk-channel` 分支的 `index.json`，
+不使用混有固件和工具链的 GitHub Latest Release。
+
+## 日常 SDK 发布
+
+1. 修改 `tools/micropixel` 的精确版本，更新 API 文档、迁移说明和验收状态。
+2. 运行 `bash tools/p4.sh test`，提交 PR。Windows 验证会构建安装器并测试实际安装后的 SDK。
+3. PR 验证通过并合并后，给同一提交创建 `sdk-v<版本>` tag 并推送。
+4. `sdk-release.yml` 构建确定性 SDK 归档、内置运行时、安装器、清单和隔离的验收副本。
+5. 安装后完成双架构构建、打包、发布预检、中文路径、增量依赖、A/B 升级回退和组件切换后，创建 Draft Release。
+6. 发布为未签名 Preview，再从公开下载地址逐一核对产物摘要，并用全新缓存重新完成实际构建。
+7. 公开复验成功后，才更新专用索引的 `preview` 和管理组件入口。`stable` 保持不变。
+
+发布 workflow 从不上传应用商店、不烧录固件，也不覆盖已经存在的 SDK Release。
+失败时查看具体步骤：Draft 创建之前可以修复并重新验证；已经创建 Release 后不要覆盖同名产物，
+修复版本需使用新版本号。公开复验失败的 Preview 不会进入自动发现索引。
+
+网站稳定 SDK 入口只引用经验证的 GitHub 归档及固定摘要，不重新打包当前工作区。
+在 Windows 稳定验收完成前，网站原有独立 SDK 入口与 Windows Preview 分开维护。
+
+## 工具链更新
+
+工具链源和编译选项固定在 `tools/windows/toolchain-sources.json`、`build_toolchain.py`。
+只有更新这些输入时才重新构建 `wamrc`。WASI 和 MSVC app-local runtime 各自固定摘要。
+
+1. 先运行 `Windows toolchain verification`，确认两种目标的原生编译和应用验证均成功。
+2. 从主分支运行 `Publish verified Windows toolchain`，输入该成功 run ID。
+3. producer 检查 run 所属仓库、workflow、提交与当前固定编译配方，核对编译器及 CRT 摘要后发布独立工具链 Release。
+4. 将已发布 `toolchain.json` 的 HTTPS 地址和 SHA-256 写入 `tools/windows/release-channel.json`。
+5. 新 SDK 发布复用此工具链，不因普通 SDK 代码或文档修改重编译 LLVM/WAMRC。
+
+`wamrc --version` 本身不能证明 AOT 兼容性；还必须保留固定 WAMR commit、来源摘要和 AOT v6 契约。
+
+## 稳定版门槛
+
+当前自动流程只发布 Preview，不能将未签名安装器或未验收版本自动提升到 `stable`。
+稳定发布仍需 [W01–W19 真机验收](windows-acceptance.zh-CN.md)、两个设备架构实际运行、
+关键故障关闭，以及受信任的 Windows 代码签名和时间戳。
+
+签名后重新核对最终安装器的 SHA-256、下载清单和安装回归，不能沿用签名前的摘要。
+在 Windows 上检查最终文件：
+
+```powershell
+Get-AuthenticodeSignature .\micropixel-setup.exe | Format-List Status, StatusMessage, SignerCertificate, TimeStamperCertificate
+Get-FileHash .\micropixel-setup.exe -Algorithm SHA256
+```
+
+Preview 预期为未签名，必须如实记录；稳定包要求 `Status = Valid`，且发布者与正式签名身份一致。
+签名基础设施与人工验收结果尚未提供，因此稳定签名与入口提升不会在当前 Preview workflow 中执行。
+性能发布说明必须有对应场景的真机证据；没有证据时 `performance` 保持空数组。

--- a/docs/development/windows-acceptance.zh-CN.md
+++ b/docs/development/windows-acceptance.zh-CN.md
@@ -24,7 +24,7 @@ GUI 安装直接双击。静默安装使用同一包：
 $process = Start-Process -FilePath '.\micropixel-setup.exe' -ArgumentList '/VERYSILENT /SUPPRESSMSGBOXES /SP- /NORESTART /LOG="install.log"' -Wait -PassThru
 if ($process.ExitCode -ne 0) { throw "Installer failed: $($process.ExitCode)" }
 $mp = "$env:LOCALAPPDATA\MicroPixel\bin\micropixel.exe"
-& $mp setup --yes --json
+& $mp setup --version 0.16.0 --yes --json
 if ($LASTEXITCODE -ne 0) { throw 'Tool preparation failed' }
 & $mp doctor --json
 ```

--- a/docs/development/windows-acceptance.zh-CN.md
+++ b/docs/development/windows-acceptance.zh-CN.md
@@ -42,6 +42,19 @@ Set-Location '.\中文 游戏\hello'
 & $mp package --aot-target xtensa --json
 ```
 
+W07–W11 使用 Release 的 `windows-acceptance-project.zip`，解压后进入 `windows-acceptance` 目录，
+在下载目录执行：
+
+```powershell
+Expand-Archive .\windows-acceptance-project.zip -DestinationPath .\硬件验收
+Set-Location .\硬件验收\windows-acceptance
+& $mp sdk use 0.16.0 --yes --json
+```
+
+该 App 在 240×240 及以上画面显示触摸与按键状态，
+日志包含 `acceptance: ready`、`touch down/up`、`key down/up`；实际操作时画面和日志都应对应变化。
+没有实体应用按键的设备记录“不适用”，仍需完成触摸测试。
+
 连接设备后的命令：
 
 ```powershell
@@ -102,7 +115,8 @@ W16 物理断网后在普通项目执行 `build --offline --json`，预期成功
 W18 脚本另输出 `Manager update and bootstrap switch passed.`，表示当前进程结束后，新命令已使用新版本目录。
 验收副本只有 build ID 不同，代码相同；finally 恢复正式索引对应组件。再手动完成卸载重装部分。
 
-W17 先执行 `publish --dry-run --json`；真实上传必须另行授权并登录，不由辅助脚本自动触发。
+W17 复制验收 App 到独立目录，将 `app.json` 的 `app_id` 改为你拥有的新测试 ID，避免覆盖任何已有 App。
+先执行 `publish --dry-run --json`；真实上传必须另行授权并登录，不由辅助脚本自动触发。
 
 ## 收集报告
 
@@ -114,6 +128,7 @@ W17 先执行 `publish --dry-run --json`；真实上传必须另行授权并登�
 
 脚本只调用离线诊断，记录系统版本、受限制的版本字段、退出码和空的 W01–W19 结果表；
 不安装、不升级、不操作设备、不上传数据。自行填写人工结果，分享前检查备注中没有个人路径或凭据。
+若 PowerShell 策略阻止辅助脚本，记录提示并由用户按本机策略批准执行；AI 不自动修改执行策略。
 安装日志只留本地；定位问题时另行提供经过脱敏的最小片段。
 
 稳定发布须完成 W01–W19、解决关键故障、验证两个架构实际运行并提供签名安装包。

--- a/docs/development/windows-acceptance.zh-CN.md
+++ b/docs/development/windows-acceptance.zh-CN.md
@@ -1,7 +1,7 @@
 # Windows 10 SDK 真机验收
 
-本清单针对 Windows 安装与版本管理项目。当前第一阶段只提供 Windows 工具链 CI，尚未发布安装器；
-以下 setup/doctor/sdk/JSON 命令属于待验收的安装管理接口，必须使用该项目后续 Preview 包，不能用 SDK 0.15.6 代替。
+本清单针对 Windows 安装与版本管理项目。使用 SDK 0.16.0 Windows Preview 安装器；
+setup/doctor/sdk/JSON 接口不能用独立 SDK 0.15.6 代替。
 CI 通过不能替代本清单。没有执行的项目标记 `not_run`，不能填写通过。
 
 ## 准备
@@ -9,7 +9,7 @@ CI 通过不能替代本清单。没有执行的项目标记 `not_run`，不能�
 - Windows 10 22H2 x64，普通用户账号，最好用户名包含中文。
 - 一款 P4/S31、一款 S3、两根可传输数据的 USB 线，设备已装匹配固件。
 - Preview Release 中的安装包、摘要、对应版本的本文及辅助脚本。
-- 两个可用的 SDK 测试版本 A/B；由发布维护者提供实际版本号，禁止伪造未发布版本。
+- Release 提供独立验收版本 A=9000.0.1、B=9000.0.2 和 `test-sdk-index.json`。两者使用相同源代码，仅版本身份不同，用来验证升级机制，不代表性能差异。
 - 测试商店发布时使用专用 App ID，不使用已有正式应用。
 
 记录安装包版本、SDK A/B 版本、系统版本、设备板型和固件版本，不记录设备 MAC、凭据或配对码。
@@ -80,19 +80,27 @@ Set-Location '.\中文 游戏\hello'
 | W18 | 更新管理组件、卸载重装 | PATH 无重复、项目保留、缓存按选择处理 | not_run |
 | W19 | 检查安全提示/签名 | Preview 提示如实记录；稳定包签名有效 | not_run |
 
-更新实验（把 A/B 替换为 Release 提供的实际版本）：
+更新实验在单独的新目录执行。以下脚本会创建两个测试项目，并显式执行 A→B→A，以及切换到附带的管理组件验收副本；
+不上传商店、不操作设备。不要把测试索引用于正式项目。
 
 ```powershell
-& $mp sdk use A --yes --json
-& $mp sdk status --check --json
-Get-FileHash .\micropixel.lock.json
-& $mp package --aot-target riscv32-ilp32f --json
-Get-FileHash .\micropixel.lock.json  # W12：与上次相同。
-& $mp sdk use B --yes --json
-& $mp build --aot-target riscv32-ilp32f --json
-& $mp sdk use A --yes --offline --json
-& $mp build --aot-target riscv32-ilp32f --offline --json
+$previousIndex = $env:MICROPIXEL_SDK_INDEX_URL
+try {
+    $env:MICROPIXEL_SDK_INDEX_URL = 'https://github.com/78/micropixel/releases/download/sdk-v0.16.0/test-sdk-index.json'
+    .\test_acceptance_versions.ps1 -Launcher $mp -Directory '.\Windows A B 验收'
+} finally {
+    $env:MICROPIXEL_SDK_INDEX_URL = $previousIndex
+    & $mp update --yes --json
+    & $mp setup --version 0.16.0 --yes --json
+}
 ```
+
+预期最后输出 `A/B update notice, explicit upgrade, dual-target rebuild, offline rollback and project isolation passed.`。
+脚本检查打包没有改锁、另一项目仍用 A、`app.json` 未变、回退可离线构建。
+W15 手动在 `setup` 下载期间断开网络，预期返回非零并保留旧项目锁；联网后重试。
+W16 物理断网后在普通项目执行 `build --offline --json`，预期成功且版本状态为 `offline`。
+W18 脚本另输出 `Manager update and bootstrap switch passed.`，表示当前进程结束后，新命令已使用新版本目录。
+验收副本只有 build ID 不同，代码相同；finally 恢复正式索引对应组件。再手动完成卸载重装部分。
 
 W17 先执行 `publish --dry-run --json`；真实上传必须另行授权并登录，不由辅助脚本自动触发。
 

--- a/docs/development/windows-sdk.zh-CN.md
+++ b/docs/development/windows-sdk.zh-CN.md
@@ -1,7 +1,10 @@
 # Windows SDK 安装与版本管理
 
-目标系统为 Windows 10 22H2 x64。当前分支正在实现 Preview，安装器须在 Windows 双架构编译验证通过后发布；
+目标系统为 Windows 10 22H2 x64。SDK 0.16.0 提供未签名 Preview 安装器，发布 workflow 在双架构编译与安装验证通过后发布；
 SDK 0.15.6 的独立归档不包含本文的安装管理组件。macOS 继续使用原有 SDK 流程。
+
+从 [SDK 0.16.0 Preview Release](https://github.com/78/micropixel/releases/tag/sdk-v0.16.0) 下载安装器和校验清单。
+双击安装器，完成后检查环境就绪提示；下载中断可点击重试。
 
 ## 安装契约
 
@@ -33,7 +36,7 @@ micropixel build --aot-target riscv32-ilp32f --json
 micropixel package --aot-target xtensa --json
 ```
 
-示例版本必须替换为发布清单中实际存在的版本。将锁文件与源码一起提交到 Git。
+后续使用发布清单中实际存在的版本。将锁文件与源码一起提交到 Git。
 锁记录精确 SDK、工具链 ID 和 SDK 清单 SHA-256。CLI、Runtime、ABI 随 SDK 一起固定。
 依赖以内容摘要存放在用户缓存，多个项目可同时使用不同版本。
 
@@ -41,6 +44,9 @@ micropixel package --aot-target xtensa --json
 micropixel sdk upgrade --yes --json
 micropixel sdk use 0.16.0 --yes --offline --json
 ```
+
+`sdk upgrade` 只选择稳定 SDK；首个 Windows Preview 尚无稳定推荐时，返回缺少选择（退出码 3），
+可显式 `sdk use 0.16.0 --yes`。Preview 不会被冒充为稳定版。
 
 升级先下载并验证全部依赖，再原子替换锁文件；失败保留旧锁。
 回退时依赖已缓存可离线执行。两个操作都不改游戏源码、`app.json` 或应用版本号。
@@ -80,3 +86,17 @@ Windows 验收使用 [W01–W19 清单](windows-acceptance.zh-CN.md)。稳定版
 Windows 10 人工验收、两个设备架构实际运行和代码签名；当前 CI 运行于 Windows Server，不能代替 Windows 10 验收。
 
 AI 安装与使用契约见 [SDK AI 指南](../../guest/sdk/AI.md)。
+
+## 卸载与缓存
+
+在 Windows“应用和功能”卸载 MicroPixel SDK。界面询问是否清除已下载缓存，默认保留。
+静默卸载同样默认保留缓存，不删除用户项目：
+
+```powershell
+$uninstaller = Get-ChildItem "$env:LOCALAPPDATA\MicroPixel" -Filter 'unins*.exe'
+if (@($uninstaller).Count -ne 1) { throw 'Expected one MicroPixel uninstaller' }
+Start-Process -FilePath $uninstaller.FullName -ArgumentList '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART' -Wait
+```
+
+仅在用户明确要求清理下载缓存时追加 `/PURGECACHE`。项目应保存在用户自己的工作目录，
+不要放在安装器管理的 `versions`、`packages` 或 `downloads` 内。

--- a/docs/development/windows-sdk.zh-CN.md
+++ b/docs/development/windows-sdk.zh-CN.md
@@ -11,13 +11,14 @@ SDK 0.15.6 的独立归档不包含本文的安装管理组件。macOS 继续使
 每个 SDK Release 提供同一个 GUI/静默安装包、`sdk-manifest.json`、安装包下载清单与 SHA-256。
 安装器按当前用户安装到 `%LOCALAPPDATA%\MicroPixel`，不要求管理员权限；
 内置 Python 3.13.12、pyserial 3.5 和管理组件，不要求用户安装 Git、CMake、LLVM、ESP-IDF 或 WSL。
+安装器同时携带本版本 SDK 的校验清单；即使更新索引暂不可用，也可以按固定版本准备依赖。
 依赖准备下载清单指定的 WASI SDK 33 和两种固定版本 `wamrc.exe`。
 
 新终端中使用 `micropixel`；当前终端尚未刷新 PATH 时使用：
 
 ```powershell
 $mp = "$env:LOCALAPPDATA\MicroPixel\bin\micropixel.exe"
-& $mp setup --yes --json
+& $mp setup --version 0.16.0 --yes --json
 & $mp doctor --json
 ```
 

--- a/guest/sdk/AI.md
+++ b/guest/sdk/AI.md
@@ -43,10 +43,12 @@ if ($LASTEXITCODE -ne 0 -or -not $doctor.ok -or -not $doctor.result.ready) { thr
 ```text
 micropixel doctor --json
 micropixel sdk status --check --json
-micropixel build --json
-micropixel package --json
+micropixel build --aot-target riscv32-ilp32f --json
+micropixel package --aot-target riscv32-ilp32f --json
 micropixel publish --dry-run --json
 ```
+
+示例目标 `riscv32-ilp32f` 用于 P4/S31；S3 使用 `xtensa`。`publish --dry-run` 自动验证两种架构。
 
 新项目使用 `micropixel init <目录> --app-id <标识> --title <名称> --json`。
 已有未锁定项目须先选择清单中的具体版本 `sdk use <版本> --yes --json`。

--- a/guest/sdk/AI.md
+++ b/guest/sdk/AI.md
@@ -6,10 +6,13 @@
 ## 安装
 
 安装必须有用户安装 SDK 的明确意图。下载清单包含 `version`、`architecture`、`url`、`size_bytes` 和 `sha256`。
-以下 PowerShell 示例中的 `$metadataUrl` 必须是已发布 Release 所提供的安装清单 HTTPS 地址：
+下面固定选择 0.16.0 Preview。自动发现使用专用 [SDK 索引](https://raw.githubusercontent.com/78/micropixel/sdk-channel/index.json)：
+`stable` 为空表示尚无稳定 Windows SDK；仅在用户接受 Preview 时使用 `preview`。
+`windows_installer` 是经过发布验证的安装器地址、大小和摘要。
 
 ```powershell
-$metadataUrl = 'https://github.com/78/micropixel/releases/download/sdk-v<VERSION>/windows-installer.json'
+# This explicit version is the unsigned Preview. Do not infer it from Latest Release.
+$metadataUrl = 'https://github.com/78/micropixel/releases/download/sdk-v0.16.0/windows-installer.json'
 $meta = Invoke-RestMethod -Uri $metadataUrl
 [Console]::OutputEncoding = [Text.UTF8Encoding]::new($false)
 $OutputEncoding = [Console]::OutputEncoding

--- a/guest/sdk/AI.md
+++ b/guest/sdk/AI.md
@@ -26,7 +26,7 @@ $log = Join-Path $env:TEMP 'micropixel-install.log'
 $p = Start-Process -FilePath $installer -ArgumentList "/VERYSILENT /SUPPRESSMSGBOXES /SP- /NORESTART /LOG=`"$log`"" -Wait -PassThru
 if ($p.ExitCode -ne 0) { throw "Installer failed: $($p.ExitCode)" }
 $mp = "$env:LOCALAPPDATA\MicroPixel\bin\micropixel.exe"
-$setup = & $mp setup --yes --json | ConvertFrom-Json
+$setup = & $mp setup --version $meta.version --yes --json | ConvertFrom-Json
 if ($LASTEXITCODE -ne 0 -or -not $setup.ok) { throw 'Environment preparation failed; see stderr' }
 $doctor = & $mp doctor --json | ConvertFrom-Json
 if ($LASTEXITCODE -ne 0 -or -not $doctor.ok -or -not $doctor.result.ready) { throw 'Environment is not ready' }

--- a/tools/build_sdk_release.py
+++ b/tools/build_sdk_release.py
@@ -44,7 +44,7 @@ def collect(root: Path) -> dict[str, bytes]:
                 continue
             if path.is_file() and path.name != 'README.md' and path.suffix != '.pyc':
                 files[relative.as_posix()] = path.read_bytes()
-    for name in ('generate_localization.py', 'analyze_sfx.py'):
+    for name in ('generate_localization.py', 'analyze_sfx.py', 'build_app_bundle.py'):
         files['libexec/' + name] = (root / 'tools' / name).read_bytes()
     return files
 
@@ -57,8 +57,8 @@ def build(root: Path) -> tuple[dict, bytes]:
         raise ValueError('SDK CLI must declare its version and one embedded-builder marker')
     version = match[1]
     files = collect(root)
-    builder = (root / 'tools/build_app_bundle.py').read_text(encoding='utf-8')
-    cli = cli.replace(MARKER, 'EMBEDDED_BUNDLE_BUILDER: str | None = ' + repr(builder))
+    # A script file avoids Windows' 32767-character CreateProcess limit.
+    cli = cli.replace(MARKER, 'EMBEDDED_BUNDLE_BUILDER = None')
     files['micropixel'] = cli.encode('utf-8')
     files['LICENSE'] = (root / 'LICENSE').read_bytes()
     files['README.md'] = f'''# MicroPixel SDK {version}

--- a/tools/build_sdk_release.py
+++ b/tools/build_sdk_release.py
@@ -67,6 +67,7 @@ Restricted C++23 Guest SDK, Runtime, ABI and six example games.
 
 Start with [Quickstart](guest/sdk/QUICKSTART.md), then read
 [Publishing](guest/sdk/PUBLISHING.md) and [Graphics](guest/sdk/GRAPHICS.md).
+Windows users and AI agents: [Installation and managed builds](guest/sdk/AI.md).
 
 ## Toolchain
 

--- a/tools/manager/micropixel_manager.py
+++ b/tools/manager/micropixel_manager.py
@@ -520,6 +520,8 @@ def execute(manager: Manager, arguments: list[str], yes: bool, json_mode: bool) 
             version = args.version if args.action == 'use' else manager.index(force=True)[0].get('stable')
             if not version:
                 raise Failure('input_required', 'Specify an SDK version or configure a stable release', 3)
+            if args.action == 'upgrade' and lock and not newer(version, lock['sdk_version']):
+                return 0, {'lock': lock, 'changed': False, 'reason': 'already_current_or_newer'}
             if args.external_toolchain:
                 if not lock or version != lock['sdk_version']:
                     raise Failure('invalid_arguments', 'External mode requires the currently locked version', 2)

--- a/tools/manager/micropixel_manager.py
+++ b/tools/manager/micropixel_manager.py
@@ -583,6 +583,12 @@ def execute(manager: Manager, arguments: list[str], yes: bool, json_mode: bool) 
     cli = load_cli(parser_path)
     parsed = cli.parser().parse_args(arguments)
     command = parsed.command
+    transport = parsed.transport or ('usb' if parsed.port else os.environ.get('MICROPIXEL_TRANSPORT', 'remote'))
+    if manager.offline and (
+        (command == 'publish' and not parsed.dry_run) or command in ('auth', 'firmware')
+        or (command in {*cli.NETWORK_COMMANDS, 'run'} and transport != 'usb')
+    ):
+        raise Failure('offline_operation', 'This operation requires network access; --offline forbids it', 4)
     if json_mode and command == 'run' and parsed.follow:
         raise Failure('invalid_arguments', 'run --json requires --no-follow', 2)
     value = getattr(parsed, 'project', getattr(parsed, 'directory', getattr(parsed, 'source', '.')))
@@ -615,6 +621,9 @@ def execute(manager: Manager, arguments: list[str], yes: bool, json_mode: bool) 
         env['WASI_CLANG'] = ''
         env['WASI_CLANGXX'] = str(Path(paths['WASI_SDK_PATH']) / 'bin/clang++.exe')
     env['MICROPIXEL_TOOLCHAIN_ID'] = manifest['toolchain_id'] if not lock.get('external_toolchain') else 'external'
+    if status and json_mode and command in ('package', 'publish'):
+        print(f"Using locked SDK {lock['sdk_version']}; update check: {status['check_status']}", file=sys.stderr)
+        show_warnings(manager.warnings)
     if status and not json_mode:
         manager.human_warnings_handled = True
         manager.human_final_status = command in ('package', 'publish')

--- a/tools/manager/micropixel_manager.py
+++ b/tools/manager/micropixel_manager.py
@@ -547,8 +547,11 @@ def execute(manager: Manager, arguments: list[str], yes: bool, json_mode: bool) 
                 raise Failure('dependency_missing', 'Bundled pyserial is missing', 4) from error
             probes = {}
             for name, path in [('clang', str(Path(paths['WASI_SDK_PATH']) / 'bin/clang++.exe')), ('riscv', paths['WAMRC']), ('xtensa', paths['XTENSA_WAMRC'])]:
-                probe = subprocess.run([path, '--version'], capture_output=True, text=True, timeout=15)
-                if probe.returncode:
+                try:
+                    probe = subprocess.run([path, '--version'], capture_output=True, text=True, timeout=15)
+                except (OSError, subprocess.TimeoutExpired) as error:
+                    raise Failure('tool_unusable', f'{name} could not execute', 4) from error
+                if probe.returncode or not (probe.stdout or probe.stderr).strip():
                     raise Failure('tool_unusable', f'{name} could not execute', 4)
                 probes[name] = (probe.stdout or probe.stderr).splitlines()[0]
             return 0, {'ready': True, 'sdk_version': lock['sdk_version'], 'toolchain_id': 'external' if lock.get('external_toolchain') else manifest['toolchain_id'], 'tools': probes, 'python_version': sys.version.split()[0], 'pyserial_version': serial_version, 'wasi_sdk_version': manifest['platforms']['windows-x64']['wasi'].get('version', 'unknown'), 'manager_version': VERSION, 'manager_build_id': BUILD_ID}

--- a/tools/micropixel
+++ b/tools/micropixel
@@ -16,6 +16,7 @@ import shutil
 import struct
 import subprocess
 import sys
+import tempfile
 import time
 import urllib.error
 import urllib.parse
@@ -200,6 +201,20 @@ def tool_executable(path: str | Path) -> Path:
             return executable
     return candidate
 
+
+
+def _run_aot_compiler(command: list[str], wasm: Path, aot: Path) -> None:
+    if sys.platform != "win32" or (str(wasm).isascii() and str(aot).isascii()):
+        _run_process([*command, "-o", str(aot), str(wasm)], check=True)
+        return
+    # The pinned WAMR fork uses narrow argv/fopen on Windows. CreateProcessW
+    # handles a Unicode working directory, so keep only ASCII filenames in argv.
+    # Stage beside the output and replace it only after a successful compilation.
+    with tempfile.TemporaryDirectory(prefix=".wamrc-", dir=aot.parent) as temporary:
+        staging = Path(temporary)
+        shutil.copyfile(wasm, staging / "module.wasm")
+        _run_process([str(Path(command[0]).absolute()), *command[1:], "-o", "module.aot", "module.wasm"], cwd=staging, check=True)
+        os.replace(staging / "module.aot", aot)
 
 def sdk_root() -> Path:
     script_directory = Path(__file__).resolve().parent
@@ -1878,7 +1893,7 @@ def _run_build_sources(args: argparse.Namespace) -> None:
         ],
         check=True,
     )
-    _run_process(
+    _run_aot_compiler(
         [
             wamrc,
             *AOT_TARGET_FLAGS[aot_target],
@@ -1891,11 +1906,9 @@ def _run_build_sources(args: argparse.Namespace) -> None:
             "--enable-dump-call-stack",
             # Experiment hook: extra wamrc flags for codegen A/B. Not a release knob.
             *shlex.split(environment.get("MICROPIXEL_WAMRC_EXTRA_FLAGS", "")),
-            "-o",
-            str(aot_output),
-            str(wasm_output),
         ],
-        check=True,
+        wasm_output,
+        aot_output,
     )
     # Feed compiler-discovered headers and toolchain files into the outer
     # project/Bundle stamp too, so its fast path cannot hide a stale object.

--- a/tools/micropixel
+++ b/tools/micropixel
@@ -408,7 +408,7 @@ def usb_serial_ports() -> list[Any]:
     try:
         from serial.tools import list_ports
     except ImportError as error:
-        raise CliError("USB transport requires pyserial; install requirements-dev.txt") from error
+        raise EnvironmentFailure("USB transport requires pyserial; run doctor or install requirements-dev.txt for a manual toolchain") from error
     return list(list_ports.comports())
 
 
@@ -428,10 +428,10 @@ def discover_usb_port(explicit_port: str | None) -> str:
         if is_micropixel_usb_candidate(port)
     ]
     if not candidates:
-        raise CliError("No MicroPixel USB device found; connect the device, run 'port list', or pass --port")
+        raise EnvironmentFailure("No MicroPixel USB device found; connect the device, run 'port list', or pass --port")
     if len(candidates) != 1:
         shown = ", ".join(sorted(candidates))
-        raise CliError(f"Multiple MicroPixel USB devices found ({shown}); pass --port")
+        raise InputRequired(f"Multiple MicroPixel USB devices found ({shown}); pass --port")
     return candidates[0]
 
 
@@ -439,7 +439,7 @@ def open_usb_serial(port: str) -> Any:
     try:
         import serial
     except ImportError as error:
-        raise CliError("USB transport requires pyserial; install requirements-dev.txt") from error
+        raise EnvironmentFailure("USB transport requires pyserial; run doctor or install requirements-dev.txt for a manual toolchain") from error
     options: dict[str, Any] = {
         "port": None,
         "baudrate": 115200,
@@ -2514,7 +2514,7 @@ def run_package(args: argparse.Namespace) -> Path:
         raise CliError("package requires a project directory or app.json")
     project = load_project_manifest(manifest_path)
     if project.package_type == "app" and getattr(args, "aot_target", None) is None:
-        raise CliError("Offline App packaging requires --aot-target")
+        raise InputRequired("Offline App packaging requires --aot-target")
     return package_project(
         project,
         args.profile,
@@ -3616,7 +3616,7 @@ def resolve_transport(args: argparse.Namespace) -> argparse.Namespace:
             args.transport = os.environ.get("MICROPIXEL_TRANSPORT", "remote")
         return args
     if args.transport == "remote" and args.port:
-        raise CliError("--port implies USB transport; omit --transport remote or pass --transport usb")
+        raise CliUsageError("--port implies USB transport; omit --transport remote or pass --transport usb")
     return args
 
 

--- a/tools/micropixel
+++ b/tools/micropixel
@@ -1935,10 +1935,12 @@ def _tool_path(name: str) -> Path:
 
 def _bundle_builder_command(arguments: list[str]) -> list[str]:
     local_builder = sdk_root() / "tools/build_app_bundle.py"
+    if not local_builder.is_file():
+        local_builder = sdk_root() / "libexec/build_app_bundle.py"
     if local_builder.is_file():
-        return [sys.executable, str(local_builder), *arguments]
+        return [sys.executable, "-X", "utf8", str(local_builder), *arguments]
     if EMBEDDED_BUNDLE_BUILDER is not None:
-        return [sys.executable, "-c", EMBEDDED_BUNDLE_BUILDER, *arguments]
+        return [sys.executable, "-X", "utf8", "-c", EMBEDDED_BUNDLE_BUILDER, *arguments]
     raise CliError("This development copy does not contain the Bundle builder")
 
 
@@ -2339,7 +2341,7 @@ def prepare_project(project: ProjectManifest, output_dir: Path) -> tuple[Path, P
     if project.value.get("localization") is not None:
         _run_process(
             [
-                sys.executable,
+                sys.executable, "-X", "utf8",
                 str(_tool_path("generate_localization.py")),
                 "--app-manifest",
                 str(project.path),
@@ -2356,7 +2358,7 @@ def prepare_project(project: ProjectManifest, output_dir: Path) -> tuple[Path, P
     sfx_manifest = project.path.parent / "audio/sfx.json"
     if sfx_manifest.is_file():
         analyze_command = [
-            sys.executable,
+            sys.executable, "-X", "utf8",
             str(_tool_path("analyze_sfx.py")),
             "--manifest",
             str(sfx_manifest),

--- a/tools/tests/test_cli_json.py
+++ b/tools/tests/test_cli_json.py
@@ -38,6 +38,15 @@ class JsonOutput(unittest.TestCase):
         self.assertEqual(result.returncode, 2)
         self.assertIn('--no-follow', value['error']['message'])
 
+    def test_package_requires_an_explicit_target_as_input(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / 'game'
+            self.call('init', root, '--app-id', 'test.json.hello', '--json')
+            result, value = self.call('package', root, '--json')
+            self.assertEqual(result.returncode, 3)
+            self.assertEqual(value['code'], 'input_required')
+            self.assertIn('--aot-target', value['error']['message'])
+
     def test_missing_compiler_is_environment_failure(self):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary) / 'game'

--- a/tools/tests/test_sdk_manager.py
+++ b/tools/tests/test_sdk_manager.py
@@ -205,6 +205,19 @@ class ManagerTests(unittest.TestCase):
         self.assertEqual(self.manager.warnings[0]['code'], 'update_check_failed')
 
 
+    def test_upgrade_does_not_downgrade_a_newer_project(self):
+        project = self.root / 'newer-project'
+        lock = {'schema_version': 1, 'sdk_version': '2.0.0', 'toolchain_id': 'fixture',
+                'manifest_sha256': 'a' * 64, 'external_toolchain': False}
+        m.atomic_json(project / m.LOCK_NAME, lock)
+        before = (project / m.LOCK_NAME).read_bytes()
+        with patch.object(self.manager, 'index', return_value=({'stable': '1.0.0'}, 'checked', 1)), patch.object(self.manager, 'switch') as switch:
+            code, result = m.execute(self.manager, ['sdk', 'upgrade', '--project', str(project)], True, True)
+        self.assertEqual(code, 0)
+        self.assertFalse(result['changed'])
+        switch.assert_not_called()
+        self.assertEqual((project / m.LOCK_NAME).read_bytes(), before)
+
     def test_offline_rejects_upload_and_remote_run_before_side_effects(self):
         manager = m.Manager(self.root / 'offline', offline=True)
         for arguments in (['publish', str(self.root)], ['run', str(self.root), '--no-follow']):

--- a/tools/tests/test_sdk_manager.py
+++ b/tools/tests/test_sdk_manager.py
@@ -205,6 +205,14 @@ class ManagerTests(unittest.TestCase):
         self.assertEqual(self.manager.warnings[0]['code'], 'update_check_failed')
 
 
+    def test_offline_rejects_upload_and_remote_run_before_side_effects(self):
+        manager = m.Manager(self.root / 'offline', offline=True)
+        for arguments in (['publish', str(self.root)], ['run', str(self.root), '--no-follow']):
+            with self.assertRaises(m.Failure) as caught:
+                m.execute(manager, arguments, True, True)
+            self.assertEqual(caught.exception.code, 'offline_operation')
+            self.assertEqual(caught.exception.exit_code, 4)
+
     def test_failed_checks_are_throttled_but_explicit_check_retries(self):
         with patch.object(m, 'fetch', side_effect=OSError('offline')) as request:
             self.manager.status('1.0.0')

--- a/tools/tests/test_sdk_release.py
+++ b/tools/tests/test_sdk_release.py
@@ -25,6 +25,7 @@ class SdkArchive(unittest.TestCase):
             self.assertFalse(any('/coastline/' in name or '/build/' in name or '/.env' in name for name in names))
             self.assertIn(prefix + 'guest/sdk/GRAPHICS.md', names)
             self.assertIn(prefix + 'LICENSE', names)
+            self.assertIn(prefix + 'libexec/build_app_bundle.py', names)
             self.assertEqual(archive.getmember(prefix + 'micropixel').mode, 0o755)
             archive.extractall(temporary, filter='data')
             cli = Path(temporary) / prefix / 'micropixel'

--- a/tools/tests/test_windows_toolchain.py
+++ b/tools/tests/test_windows_toolchain.py
@@ -2,6 +2,7 @@
 import tempfile
 import unittest
 from unittest.mock import patch
+from types import SimpleNamespace
 from pathlib import Path
 
 from tools.tests.test_micropixel_cli import CLI
@@ -17,6 +18,16 @@ class WindowsDependencies(unittest.TestCase):
                 Path(r'C:\Users\dev\game\main.cpp').absolute(),
                 Path('C:/中文/my game/header.hpp').absolute(),
             })
+
+    def test_usb_discovery_distinguishes_environment_and_missing_selection(self):
+        with patch.object(CLI, 'usb_serial_ports', return_value=[]):
+            with self.assertRaises(CLI.EnvironmentFailure):
+                CLI.discover_usb_port(None)
+        ports = [SimpleNamespace(device=name, vid=0x303A, pid=0x1001, product='MicroPixel') for name in ('COM4', 'COM5')]
+        with patch.object(CLI, 'usb_serial_ports', return_value=ports):
+            with self.assertRaises(CLI.InputRequired):
+                CLI.discover_usb_port(None)
+            self.assertEqual(CLI.discover_usb_port('COM5'), 'COM5')
 
     def test_wamrc_unicode_staging_preserves_output_on_failure(self):
         with tempfile.TemporaryDirectory(prefix='中文 game ') as temporary:

--- a/tools/tests/test_windows_toolchain.py
+++ b/tools/tests/test_windows_toolchain.py
@@ -1,6 +1,7 @@
 """Windows path regressions, runnable on POSIX and Windows."""
 import tempfile
 import unittest
+from unittest.mock import patch
 from pathlib import Path
 
 from tools.tests.test_micropixel_cli import CLI
@@ -16,6 +17,25 @@ class WindowsDependencies(unittest.TestCase):
                 Path(r'C:\Users\dev\game\main.cpp').absolute(),
                 Path('C:/中文/my game/header.hpp').absolute(),
             })
+
+    def test_wamrc_unicode_staging_preserves_output_on_failure(self):
+        with tempfile.TemporaryDirectory(prefix='中文 game ') as temporary:
+            root = Path(temporary)
+            wasm, aot = root / '游戏.wasm', root / '游戏.aot'
+            wasm.write_bytes(b'wasm input')
+            aot.write_bytes(b'previous output')
+            def compile(command, *, cwd, check):
+                self.assertEqual(command[-3:], ['-o', 'module.aot', 'module.wasm'])
+                self.assertEqual((cwd / 'module.wasm').read_bytes(), b'wasm input')
+                (cwd / 'module.aot').write_bytes(b'new output')
+            with patch.object(CLI.sys, 'platform', 'win32'), patch.object(CLI, '_run_process', side_effect=OSError('interrupted')):
+                with self.assertRaises(OSError):
+                    CLI._run_aot_compiler(['wamrc'], wasm, aot)
+            self.assertEqual(aot.read_bytes(), b'previous output')
+            with patch.object(CLI.sys, 'platform', 'win32'), patch.object(CLI, '_run_process', side_effect=compile):
+                CLI._run_aot_compiler(['wamrc'], wasm, aot)
+            self.assertEqual(aot.read_bytes(), b'new output')
+            self.assertEqual(list(root.glob('.wamrc-*')), [])
 
     def test_make_escapes_and_continuations_are_preserved(self):
         with tempfile.TemporaryDirectory() as temporary:

--- a/tools/windows/build_installer.py
+++ b/tools/windows/build_installer.py
@@ -2,7 +2,6 @@
 """Build the unsigned Preview installer. Signing/stable promotion is a separate gate."""
 import argparse
 import json
-import re
 import subprocess
 import sys
 import urllib.request
@@ -11,6 +10,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT / 'tools'))
 from windows.release_metadata import asset
+from windows.prepare_sdk_release import prepare_core
 from manager.micropixel_manager import file_digest
 
 
@@ -25,7 +25,7 @@ def main():
     args = parser.parse_args()
     output = args.output.resolve()
     output.mkdir(parents=True, exist_ok=True)
-    version = re.search(r'^VERSION = "([0-9.]+)"$', (ROOT / 'tools/micropixel').read_text(), re.M)[1]
+    version = prepare_core(output, args.repository)['version']
     run(sys.executable, ROOT / 'tools/windows/build_manager.py', '--output', output / 'runtime')
     build = json.loads((output / 'runtime/manager-build.json').read_text())
     build_id = build['build_id']

--- a/tools/windows/collect_acceptance.ps1
+++ b/tools/windows/collect_acceptance.ps1
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+﻿# SPDX-License-Identifier: Apache-2.0
 # Read-only environment collection. Never installs, upgrades, flashes or uploads.
 [CmdletBinding()]
 param(

--- a/tools/windows/fixtures/acceptance/app.json
+++ b/tools/windows/fixtures/acceptance/app.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "app_id": "local.windows.acceptance",
+  "version": "0.1.0",
+  "threading": "none",
+  "title": "SDK Acceptance",
+  "sources": ["main.cpp"],
+  "requirements": {
+    "schema_version": 1,
+    "display": {"layouts": ["square", "portrait", "landscape"], "min_width": 240, "min_height": 240},
+    "required": [],
+    "optional": ["input.touch", "input.keys"],
+    "any_of": [],
+    "services": {}
+  }
+}

--- a/tools/windows/fixtures/acceptance/main.cpp
+++ b/tools/windows/fixtures/acceptance/main.cpp
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+#include "sdk/micropixel.hpp"
+
+int main() {
+    micropixel::Application app;
+    auto renderer = app.renderer();
+    auto scene = renderer.CreateScene(micropixel::Color::Black()).value();
+    (void)scene.CreateLabel({12, 16}, "SDK acceptance", micropixel::Color::White(), micropixel::SystemFont::kSmall)
+        .value();
+    auto touch_label =
+        scene.CreateLabel({12, 56}, "Touch: waiting", micropixel::Color::White(), micropixel::SystemFont::kSmall)
+            .value();
+    auto key_label =
+        scene.CreateLabel({12, 96}, "Key: waiting", micropixel::Color::White(), micropixel::SystemFont::kSmall).value();
+    renderer.Present(scene).value();
+    app.log().Info("acceptance: ready");
+    app.Run([&](const micropixel::Event& event) {
+        bool changed = false;
+        if (const auto* touch = event.touch()) {
+            if (touch->phase() == micropixel::TouchPhase::kDown) {
+                touch_label.SetText("Touch: DOWN");
+                app.log().Info("acceptance: touch down");
+                changed = true;
+            } else if (touch->phase() == micropixel::TouchPhase::kUp ||
+                       touch->phase() == micropixel::TouchPhase::kCancel) {
+                touch_label.SetText("Touch: UP");
+                app.log().Info("acceptance: touch up");
+                changed = true;
+            }
+        } else if (const auto* key = event.key()) {
+            if (key->phase() == micropixel::KeyPhase::kDown) {
+                key_label.SetText("Key: DOWN");
+                app.log().Info("acceptance: key down");
+                changed = true;
+            } else if (key->phase() == micropixel::KeyPhase::kUp || key->phase() == micropixel::KeyPhase::kCancel) {
+                key_label.SetText("Key: UP");
+                app.log().Info("acceptance: key up");
+                changed = true;
+            }
+        }
+        if (changed || event.type() == micropixel::EventType::kResume) {
+            renderer.Present(scene).value();
+        }
+    });
+    return 0;
+}

--- a/tools/windows/micropixel.iss
+++ b/tools/windows/micropixel.iss
@@ -38,6 +38,8 @@ UninstallDisplayName=MicroPixel SDK Preview
 LicenseFile=..\..\LICENSE
 
 [Files]
+; The installer pins its own SDK independently of the mutable update channel.
+Source: "{#ReleaseDir}\sdk-manifest.json"; DestDir: "{app}\manifests"; DestName: "{#SdkVersion}.json"; Flags: ignoreversion onlyifdoesntexist uninsneveruninstall
 Source: "{#PayloadDir}\{#ManagerBuild}\*"; DestDir: "{app}\versions\{#ManagerBuild}"; Flags: recursesubdirs createallsubdirs ignoreversion onlyifdoesntexist
 Source: "{#PayloadDir}\micropixel.exe"; DestDir: "{app}\bin"; Flags: ignoreversion
 Source: "..\..\docs\development\windows-sdk.zh-CN.md"; DestDir: "{app}\docs"; Flags: ignoreversion

--- a/tools/windows/prepare_sdk_release.py
+++ b/tools/windows/prepare_sdk_release.py
@@ -63,6 +63,11 @@ def main():
         manifest_path = out / f'test-sdk-{fixture_version}.json'
         write_json(manifest_path, fixture_manifest)
         entries[fixture_version] = {**asset(manifest_path, base, ''), 'release_notes_url': manifest['release_notes_url'], 'performance': []}
+    with tempfile.TemporaryDirectory() as temporary:
+        fixture_source = Path(temporary)
+        for name in ('app.json', 'main.cpp'):
+            shutil.copyfile(ROOT / 'tools/windows/fixtures/acceptance' / name, fixture_source / name)
+        zip_archive(fixture_source, out / 'windows-acceptance-project.zip', 'windows-acceptance')
     runtime = json.loads((out / 'runtime/manager-build.json').read_text())
     manager_path = out / runtime['archive']
     shutil.copyfile(out / 'runtime' / runtime['archive'], manager_path)

--- a/tools/windows/prepare_sdk_release.py
+++ b/tools/windows/prepare_sdk_release.py
@@ -17,8 +17,6 @@ from windows.release_metadata import archive as zip_archive, asset, file_digest,
 
 def prepare_core(out: Path, repository: str):
     metadata, archive = packager.build(ROOT)
-    version = metadata['version']
-    base = f'https://github.com/{repository}/releases/download/sdk-v{version}'
     pin = json.loads((ROOT / 'tools/windows/release-channel.json').read_text())
     toolchain = out / 'toolchain.json'
     if not toolchain.exists() or file_digest(toolchain) != pin['sha256']:
@@ -81,7 +79,7 @@ def main():
     fixture_manager = {**asset(fixture_manager_path, base, 'manager'), 'version': runtime['version'], 'build_id': fixture_build['build_id']}
     write_json(out / 'test-sdk-index.json', {'schema_version': 1, 'test_only': True, 'stable': '9000.0.2', 'preview': None, 'versions': entries, 'manager': fixture_manager})
     write_json(out / 'channel-entry.json', {'schema_version': 1, 'version': version, 'entry': entries[version], 'manager': manager,
-                                          'installer': asset(out / json.loads((out / 'windows-installer.json').read_text())['name'], base, '')})
+                                          'installer': json.loads((out / 'windows-installer.json').read_text())})
     write_json(out / 'release-notes.json', {'schema_version': 1, 'sdk_version': version, 'channel': 'preview',
         'performance': [], 'migration': ['Existing unmanaged projects must explicitly select an SDK before managed builds.',
         'Source migration and real-device acceptance remain separate from SDK switching.'],

--- a/tools/windows/prepare_sdk_release.py
+++ b/tools/windows/prepare_sdk_release.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Build release metadata and isolated A/B acceptance fixtures from one checkout."""
+import argparse
+import json
+import re
+import shutil
+import sys
+import tempfile
+import urllib.request
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / 'tools'))
+import build_sdk_release as packager
+from windows.release_metadata import archive as zip_archive, asset, file_digest, sdk, write, write_json
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--directory', type=Path, required=True)
+    parser.add_argument('--repository', default='78/micropixel')
+    args = parser.parse_args()
+    out = args.directory.resolve()
+    out.mkdir(parents=True, exist_ok=True)
+    metadata, archive = packager.build(ROOT)
+    version = metadata['version']
+    base = f'https://github.com/{args.repository}/releases/download/sdk-v{version}'
+    pin = json.loads((ROOT / 'tools/windows/release-channel.json').read_text())
+    toolchain = out / 'toolchain.json'
+    urllib.request.urlretrieve(pin['url'], toolchain)
+    if file_digest(toolchain) != pin['sha256']:
+        raise SystemExit('Published toolchain manifest checksum differs from release pin')
+    write(out / metadata['archiveName'], archive)
+    write_json(out / 'release.json', metadata)
+    sdk(out, toolchain, out, args.repository)
+    manifest = json.loads((out / 'sdk-manifest.json').read_text())
+    entries = {version: {**asset(out / 'sdk-manifest.json', base, ''), 'release_notes_url': manifest['release_notes_url'], 'performance': []}}
+    # These numeric versions are acceptance fixtures, never production channels.
+    # Only the CLI identity changes; no invented performance or API claims.
+    for fixture_version in ('9000.0.1', '9000.0.2'):
+        with tempfile.TemporaryDirectory() as temporary:
+            source = Path(temporary)
+            for relative, content in packager.collect(ROOT).items():
+                path = source / relative
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_bytes(content)
+            for relative in ('tools/micropixel', 'tools/build_app_bundle.py', 'tools/generate_localization.py', 'tools/analyze_sfx.py', 'LICENSE'):
+                path = source / relative
+                path.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copyfile(ROOT / relative, path)
+            cli = source / 'tools/micropixel'
+            cli.write_text(re.sub(r'^VERSION = "[0-9.]+"$', f'VERSION = "{fixture_version}"', cli.read_text(), flags=re.M))
+            fixture_meta, fixture_bytes = packager.build(source)
+        fixture_path = out / fixture_meta['archiveName']
+        write(fixture_path, fixture_bytes)
+        fixture_manifest = {**manifest, 'sdk_version': fixture_version, 'test_only': True,
+                            'sdk': asset(fixture_path, base, 'micropixel-sdk-' + fixture_version)}
+        manifest_path = out / f'test-sdk-{fixture_version}.json'
+        write_json(manifest_path, fixture_manifest)
+        entries[fixture_version] = {**asset(manifest_path, base, ''), 'release_notes_url': manifest['release_notes_url'], 'performance': []}
+    runtime = json.loads((out / 'runtime/manager-build.json').read_text())
+    manager_path = out / runtime['archive']
+    shutil.copyfile(out / 'runtime' / runtime['archive'], manager_path)
+    manager = {**asset(manager_path, base, 'manager'), 'version': runtime['version'], 'build_id': runtime['build_id']}
+    with tempfile.TemporaryDirectory() as temporary:
+        fixture_runtime = Path(temporary) / 'manager'
+        shutil.copytree(out / 'runtime' / runtime['directory'], fixture_runtime)
+        fixture_build = json.loads((fixture_runtime / 'build.json').read_text())
+        fixture_build['build_id'] += '-acceptance'
+        write_json(fixture_runtime / 'acceptance.json', {'test_only': True, 'purpose': 'Exercise version-directory switching; identical manager code'})
+        (fixture_runtime / 'build.json').write_text(json.dumps(fixture_build, indent=2) + '\n')
+        fixture_manager_path = out / ('micropixel-manager-' + fixture_build['build_id'] + '.zip')
+        zip_archive(fixture_runtime, fixture_manager_path, 'manager')
+    fixture_manager = {**asset(fixture_manager_path, base, 'manager'), 'version': runtime['version'], 'build_id': fixture_build['build_id']}
+    write_json(out / 'test-sdk-index.json', {'schema_version': 1, 'test_only': True, 'stable': '9000.0.2', 'preview': None, 'versions': entries, 'manager': fixture_manager})
+    write_json(out / 'channel-entry.json', {'schema_version': 1, 'version': version, 'entry': entries[version], 'manager': manager,
+                                          'installer': asset(out / json.loads((out / 'windows-installer.json').read_text())['name'], base, '')})
+    write_json(out / 'release-notes.json', {'schema_version': 1, 'sdk_version': version, 'channel': 'preview',
+        'performance': [], 'migration': ['Existing unmanaged projects must explicitly select an SDK before managed builds.',
+        'Source migration and real-device acceptance remain separate from SDK switching.'],
+        'compatibility': manifest['compatibility'], 'windows_acceptance': 'pending', 'code_signing': 'unsigned-preview'})
+    for relative in ('docs/development/windows-sdk.zh-CN.md', 'docs/development/windows-acceptance.zh-CN.md',
+                     'guest/sdk/AI.md', 'tools/windows/collect_acceptance.ps1', 'tools/windows/test_acceptance_versions.ps1', 'LICENSE', 'THIRD_PARTY_NOTICES.md'):
+        shutil.copyfile(ROOT / relative, out / Path(relative).name)
+    assets = sorted(path for path in out.iterdir() if path.is_file() and path.name not in ('inno-setup.exe', 'sha256sums.txt', 'release-notes.md'))
+    write(out / 'sha256sums.txt', ''.join(file_digest(p) + '  ' + p.name + '\n' for p in assets).encode())
+    print(version)
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/windows/prepare_sdk_release.py
+++ b/tools/windows/prepare_sdk_release.py
@@ -15,6 +15,21 @@ import build_sdk_release as packager
 from windows.release_metadata import archive as zip_archive, asset, file_digest, sdk, write, write_json
 
 
+def prepare_core(out: Path, repository: str):
+    metadata, archive = packager.build(ROOT)
+    version = metadata['version']
+    base = f'https://github.com/{repository}/releases/download/sdk-v{version}'
+    pin = json.loads((ROOT / 'tools/windows/release-channel.json').read_text())
+    toolchain = out / 'toolchain.json'
+    if not toolchain.exists() or file_digest(toolchain) != pin['sha256']:
+        urllib.request.urlretrieve(pin['url'], toolchain)
+    if file_digest(toolchain) != pin['sha256']:
+        raise SystemExit('Published toolchain manifest checksum differs from release pin')
+    write(out / metadata['archiveName'], archive)
+    write_json(out / 'release.json', metadata)
+    sdk(out, toolchain, out, repository)
+    return metadata
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--directory', type=Path, required=True)
@@ -22,17 +37,9 @@ def main():
     args = parser.parse_args()
     out = args.directory.resolve()
     out.mkdir(parents=True, exist_ok=True)
-    metadata, archive = packager.build(ROOT)
+    metadata = prepare_core(out, args.repository)
     version = metadata['version']
     base = f'https://github.com/{args.repository}/releases/download/sdk-v{version}'
-    pin = json.loads((ROOT / 'tools/windows/release-channel.json').read_text())
-    toolchain = out / 'toolchain.json'
-    urllib.request.urlretrieve(pin['url'], toolchain)
-    if file_digest(toolchain) != pin['sha256']:
-        raise SystemExit('Published toolchain manifest checksum differs from release pin')
-    write(out / metadata['archiveName'], archive)
-    write_json(out / 'release.json', metadata)
-    sdk(out, toolchain, out, args.repository)
     manifest = json.loads((out / 'sdk-manifest.json').read_text())
     entries = {version: {**asset(out / 'sdk-manifest.json', base, ''), 'release_notes_url': manifest['release_notes_url'], 'performance': []}}
     # These numeric versions are acceptance fixtures, never production channels.

--- a/tools/windows/publish_sdk.py
+++ b/tools/windows/publish_sdk.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Publish immutable Preview assets, then promote only verified releases to a channel."""
+import argparse
+import json
+import os
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+def run(*args, **kwargs):
+    return subprocess.run(list(map(str, args)), check=True, **kwargs)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('action', choices=['draft', 'publish', 'promote'])
+    parser.add_argument('--directory', type=Path, required=True)
+    args = parser.parse_args()
+    out = args.directory.resolve()
+    entry = json.loads((out / 'channel-entry.json').read_text())
+    version = entry['version']
+    if not re.fullmatch(r'[0-9]+\.[0-9]+\.[0-9]+', version):
+        raise SystemExit('Invalid SDK version')
+    tag = 'sdk-v' + version
+    if os.environ.get('GITHUB_REF_TYPE') == 'tag' and os.environ['GITHUB_REF_NAME'] != tag:
+        raise SystemExit('Tag and packaged CLI versions differ')
+    if args.action == 'draft':
+        if subprocess.run(['gh', 'release', 'view', tag], capture_output=True).returncode == 0:
+            raise SystemExit('Release already exists; refusing to replace immutable assets')
+        if not json.loads((out / 'draft-verification.json').read_text()).get('ok'):
+            raise SystemExit('Installed draft verification is required')
+        notes = out / 'release-notes.md'
+        notes.write_text(f'''# MicroPixel SDK {version} Windows Preview
+
+Per-user GUI and silent installer with embedded Python 3.13.12/pyserial 3.5,
+verified WASI SDK 33 and fixed RISC-V/Xtensa AOT v6 compilers.
+
+- Start with the attached Windows guide or AI.md; installer success alone does not mean ready.
+- Project SDK/toolchain versions are locked; upgrading and rolling back are explicit.
+- Unsigned Preview: Windows 10 GUI/security/USB acceptance and code signing remain pending.
+- `test-sdk-index.json` and SDK 9000.0.1/9000.0.2 are isolated acceptance fixtures only.
+- No new performance claim is made. Existing macOS toolchain usage remains supported.
+
+Do not use the test index for production projects. See windows-acceptance.zh-CN.md.
+''', encoding='utf-8')
+        run('gh', 'release', 'create', tag, '--draft', '--prerelease', '--latest=false', '--target', os.environ['GITHUB_SHA'],
+            '--title', f'SDK {version} Windows Preview', '--notes-file', notes)
+        names = [line.split('  ', 1)[1] for line in (out / 'sha256sums.txt').read_text().splitlines()]
+        run('gh', 'release', 'upload', tag, *[out / name for name in names], out / 'sha256sums.txt', out / 'draft-verification.json')
+    elif args.action == 'publish':
+        run('gh', 'release', 'edit', tag, '--draft=false', '--prerelease', '--latest=false')
+    else:
+        report = json.loads((out / 'public-verification.json').read_text())
+        if not report.get('ok') or report.get('sdk_version') != version:
+            raise SystemExit('Public download and installed build verification is required')
+        # Preview promotion cannot set the stable SDK pointer. Stable promotion
+        # needs a separate signed release and completed W01-W19 hardware review.
+        remote = subprocess.check_output(['git', 'remote', 'get-url', 'origin'], text=True).strip()
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = Path(temporary)
+            run('git', 'init', directory)
+            run('git', '-C', directory, 'remote', 'add', 'origin', remote)
+            exists = subprocess.check_output(['git', 'ls-remote', '--heads', 'origin', 'sdk-channel'], text=True).strip()
+            if exists:
+                run('git', '-C', directory, 'fetch', '--depth=1', 'origin', 'sdk-channel')
+                run('git', '-C', directory, 'checkout', '-b', 'sdk-channel', 'FETCH_HEAD')
+                index = json.loads((directory / 'index.json').read_text())
+            else:
+                run('git', '-C', directory, 'checkout', '--orphan', 'sdk-channel')
+                index = {'schema_version': 1, 'stable': None, 'preview': None, 'versions': {}}
+            if version in index['versions'] and index['versions'][version] != entry['entry']:
+                raise SystemExit('Channel version identity is immutable')
+            index['versions'][version] = entry['entry']
+            index.update(preview=version, manager=entry['manager'], windows_installer=entry['installer'])
+            (directory / 'index.json').write_text(json.dumps(index, indent=2, sort_keys=True) + '\n')
+            run('git', '-C', directory, 'config', 'user.name', 'MicroPixel release')
+            run('git', '-C', directory, 'config', 'user.email', 'release@users.noreply.github.com')
+            run('git', '-C', directory, 'add', 'index.json')
+            run('git', '-C', directory, 'commit', '-m', f'Promote verified SDK {version} Preview')
+            # A concurrent channel change fails normally; never force-push it.
+            run('git', '-C', directory, 'push', 'origin', 'HEAD:refs/heads/sdk-channel')
+        run('gh', 'release', 'upload', tag, out / 'public-verification.json')
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/windows/release-channel.json
+++ b/tools/windows/release-channel.json
@@ -1,0 +1,5 @@
+{
+  "schema_version": 1,
+  "url": "https://github.com/78/micropixel/releases/download/toolchain-windows-x64-14b0c01b909a3fab/toolchain.json",
+  "sha256": "373fa32c57b58b4b65196c24482ec5f339ec28efc0517dce2f45e249dcb12ba3"
+}

--- a/tools/windows/test_acceptance_versions.ps1
+++ b/tools/windows/test_acceptance_versions.ps1
@@ -27,7 +27,7 @@ $appBefore = Get-FileHash -LiteralPath (Join-Path $a 'app.json')
 $lockBefore = Get-FileHash -LiteralPath (Join-Path $a 'micropixel.lock.json')
 $status = Invoke-MicroPixel @('sdk', 'status', '--project', $a, '--check')
 if (-not $OfflineFixtures -and $status.result.candidate_version -ne '9000.0.2') { throw 'Test channel did not recommend fixture B' }
-Invoke-MicroPixel @('package', $a) | Out-Null
+Invoke-MicroPixel @('package', $a, '--aot-target', 'riscv32-ilp32f') | Out-Null
 if ((Get-FileHash -LiteralPath (Join-Path $a 'micropixel.lock.json')).Hash -ne $lockBefore.Hash) { throw 'Package silently changed the project lock' }
 if ($OfflineFixtures) {
     Invoke-MicroPixel @('sdk', 'use', '9000.0.2', '--project', $a, '--yes') | Out-Null
@@ -38,7 +38,7 @@ foreach ($target in @('riscv32-ilp32f', 'xtensa')) {
     Invoke-MicroPixel @('package', $a, '--aot-target', $target) | Out-Null
 }
 Invoke-MicroPixel @('sdk', 'use', '9000.0.1', '--project', $a, '--yes', '--offline') | Out-Null
-Invoke-MicroPixel @('build', $a, '--offline') | Out-Null
+Invoke-MicroPixel @('build', $a, '--aot-target', 'riscv32-ilp32f', '--offline') | Out-Null
 if ((Get-FileHash -LiteralPath (Join-Path $a 'app.json')).Hash -ne $appBefore.Hash) { throw 'SDK switching modified app.json' }
 if ((Get-FileHash -LiteralPath (Join-Path $other 'micropixel.lock.json')).Hash -ne $otherLock.Hash) { throw 'SDK switching changed another project' }
 $before = Invoke-MicroPixel @('manager-version')

--- a/tools/windows/test_acceptance_versions.ps1
+++ b/tools/windows/test_acceptance_versions.ps1
@@ -1,0 +1,49 @@
+﻿# Explicit test-only A/B migration exercise. Does not publish or access devices.
+[CmdletBinding()]
+param(
+    [string]$Launcher = "$env:LOCALAPPDATA\MicroPixel\bin\micropixel.exe",
+    [Parameter(Mandatory=$true)][string]$Directory,
+    [switch]$OfflineFixtures
+)
+$ErrorActionPreference = 'Stop'
+[Console]::OutputEncoding = [Text.UTF8Encoding]::new($false)
+$Directory = [IO.Path]::GetFullPath($Directory)
+if (Test-Path -LiteralPath $Directory) { throw 'Use a new empty test directory; existing projects are never overwritten' }
+New-Item -ItemType Directory -Path $Directory | Out-Null
+function Invoke-MicroPixel([string[]]$Command) {
+    $raw = & $Launcher @Command --json
+    $code = $LASTEXITCODE
+    $result = $raw | ConvertFrom-Json
+    if ($code -ne 0 -or -not $result.ok) { throw "Test command failed ($code): $($Command -join ' '); $($result.code)" }
+    return $result
+}
+$a = Join-Path $Directory '中文 游戏 A'
+$other = Join-Path $Directory '保持 A'
+Invoke-MicroPixel @('setup', '--version', '9000.0.1', '--yes') | Out-Null
+Invoke-MicroPixel @('init', $a, '--app-id', 'local.acceptance-a', '--title', 'Acceptance A') | Out-Null
+Invoke-MicroPixel @('init', $other, '--app-id', 'local.acceptance-other', '--title', 'Acceptance Other') | Out-Null
+$otherLock = Get-FileHash -LiteralPath (Join-Path $other 'micropixel.lock.json')
+$appBefore = Get-FileHash -LiteralPath (Join-Path $a 'app.json')
+$lockBefore = Get-FileHash -LiteralPath (Join-Path $a 'micropixel.lock.json')
+$status = Invoke-MicroPixel @('sdk', 'status', '--project', $a, '--check')
+if (-not $OfflineFixtures -and $status.result.candidate_version -ne '9000.0.2') { throw 'Test channel did not recommend fixture B' }
+Invoke-MicroPixel @('package', $a) | Out-Null
+if ((Get-FileHash -LiteralPath (Join-Path $a 'micropixel.lock.json')).Hash -ne $lockBefore.Hash) { throw 'Package silently changed the project lock' }
+if ($OfflineFixtures) {
+    Invoke-MicroPixel @('sdk', 'use', '9000.0.2', '--project', $a, '--yes') | Out-Null
+} else {
+    Invoke-MicroPixel @('sdk', 'upgrade', '--project', $a, '--yes') | Out-Null
+}
+foreach ($target in @('riscv32-ilp32f', 'xtensa')) {
+    Invoke-MicroPixel @('package', $a, '--aot-target', $target) | Out-Null
+}
+Invoke-MicroPixel @('sdk', 'use', '9000.0.1', '--project', $a, '--yes', '--offline') | Out-Null
+Invoke-MicroPixel @('build', $a, '--offline') | Out-Null
+if ((Get-FileHash -LiteralPath (Join-Path $a 'app.json')).Hash -ne $appBefore.Hash) { throw 'SDK switching modified app.json' }
+if ((Get-FileHash -LiteralPath (Join-Path $other 'micropixel.lock.json')).Hash -ne $otherLock.Hash) { throw 'SDK switching changed another project' }
+$before = Invoke-MicroPixel @('manager-version')
+$update = Invoke-MicroPixel @('update', '--yes')
+$after = Invoke-MicroPixel @('manager-version')
+if (-not $update.result.updated -or $before.result.build_id -eq $after.result.build_id -or $after.result.build_id -ne $update.result.candidate_build_id) { throw 'Manager version-directory switch was not exercised' }
+Write-Host 'Manager update and bootstrap switch passed.'
+Write-Host 'A/B update notice, explicit upgrade, dual-target rebuild, offline rollback and project isolation passed.'

--- a/tools/windows/verify_installed_sdk.py
+++ b/tools/windows/verify_installed_sdk.py
@@ -72,6 +72,10 @@ def main():
     project = root / '中文 游戏 & app'
     invoke('init', str(project), '--app-id', 'local.windows-verification', '--title', 'Windows Verification')
     lock_before = (project / 'micropixel.lock.json').read_bytes()
+    source = project / 'src/main.cpp'
+    source.write_text('#include \"cache_probe.hpp\"\n' + source.read_text(encoding='utf-8'), encoding='utf-8')
+    header = project / 'src/cache_probe.hpp'
+    header.write_text('#define CACHE_PROBE 1\n')
     for target in ('riscv32-ilp32f', 'xtensa'):
         invoke('build', str(project), '--aot-target', target, '--offline')
         invoke('package', str(project), '--aot-target', target, '--offline')
@@ -83,6 +87,11 @@ def main():
         invoke('package', str(project), '--aot-target', target, '--offline')
         if any(p.stat().st_mtime_ns != stamp for p, stamp in files.items()):
             raise RuntimeError('Incremental package rewrote build outputs')
+    previous_aot = {p: p.stat().st_mtime_ns for p in (project / 'build').glob('*.aot')}
+    header.write_text('#define CACHE_PROBE 2\n')
+    invoke('package', str(project), '--aot-target', 'xtensa', '--offline')
+    if not previous_aot or any(p.stat().st_mtime_ns == stamp for p, stamp in previous_aot.items()):
+        raise RuntimeError('Changed header did not invalidate cached AOT')
     invoke('publish', str(project), '--dry-run', '--offline')
     if (project / 'micropixel.lock.json').read_bytes() != lock_before:
         raise RuntimeError('Build/package/preflight modified the project lock')

--- a/tools/windows/verify_installed_sdk.py
+++ b/tools/windows/verify_installed_sdk.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Exercise installed tools with developer tools removed from PATH; never upload apps."""
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / 'tools'))
+from windows.release_metadata import file_digest
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--directory', type=Path, required=True)
+    parser.add_argument('--public', action='store_true')
+    args = parser.parse_args()
+    out = args.directory.resolve()
+    entry = json.loads((out / 'channel-entry.json').read_text())
+    version = entry['version']
+    root = Path(os.environ['RUNNER_TEMP']) / ('mp-public' if args.public else 'mp-draft')
+    if root.exists():
+        raise SystemExit('Integration requires a fresh cache')
+    root.mkdir()
+    launcher = Path(os.environ['LOCALAPPDATA']) / 'MicroPixel/bin/micropixel.exe'
+    env = dict(os.environ)
+    env.update(MICROPIXEL_HOME=str(root), MICROPIXEL_SDK_INDEX_URL=entry['entry']['url'].rsplit('/', 1)[0] + '/test-sdk-index.json')
+    # Native tools must not accidentally find CI's Python/Git/CMake/LLVM/CRT.
+    env['PATH'] = str(Path(env['WINDIR']) / 'System32')
+    for key in ('WASI_SDK_PATH', 'WASI_CLANG', 'WASI_CLANGXX', 'WAMRC', 'XTENSA_WAMRC', 'PYTHONPATH', 'PYTHONHOME'):
+        env.pop(key, None)
+    index = json.loads((out / 'test-sdk-index.json').read_text())
+    if not args.public:
+        (root / 'manifests').mkdir()
+        (root / 'downloads').mkdir()
+        for sdk_version, spec in index['versions'].items():
+            manifest_path = out / spec['name']
+            shutil.copyfile(manifest_path, root / 'manifests' / (sdk_version + '.json'))
+            asset = json.loads(manifest_path.read_text())['sdk']
+            shutil.copyfile(out / asset['name'], root / 'downloads' / asset['sha256'])
+        shutil.copyfile(out / index['manager']['name'], root / 'downloads' / index['manager']['sha256'])
+        (root / 'index-cache.json').write_text(json.dumps({'url': env['MICROPIXEL_SDK_INDEX_URL'], 'index': index,
+            'checked_at': int(time.time()), 'attempted_at': int(time.time())}))
+    else:
+        # Independently fetch and verify every published small/SDK/installer asset.
+        for line in (out / 'sha256sums.txt').read_text().splitlines():
+            expected, name = line.split('  ', 1)
+            path = root / name
+            urllib.request.urlretrieve(entry['entry']['url'].rsplit('/', 1)[0] + '/' + name, path)
+            if file_digest(path) != expected:
+                raise SystemExit('Public release asset differs: ' + name)
+            path.unlink()
+
+    def invoke(*command):
+        process = subprocess.run([str(launcher), *command, '--json'], env=env, cwd=root,
+                                 capture_output=True, text=True, encoding='utf-8', timeout=900)
+        print(process.stderr, file=sys.stderr, end='')
+        result = json.loads(process.stdout)
+        if process.returncode or not result.get('ok') or result.get('schema_version') != 1:
+            raise RuntimeError(f'Installed command failed {command}: {result}')
+        return result
+
+    invoke('setup', '--version', version, '--yes')
+    doctor = invoke('doctor', '--offline')
+    if not doctor['result']['ready']:
+        raise RuntimeError('Prepared tools did not pass doctor')
+    project = root / '中文 游戏 & app'
+    invoke('init', str(project), '--app-id', 'local.windows-verification', '--title', 'Windows Verification')
+    lock_before = (project / 'micropixel.lock.json').read_bytes()
+    for target in ('riscv32-ilp32f', 'xtensa'):
+        invoke('build', str(project), '--aot-target', target, '--offline')
+        invoke('package', str(project), '--aot-target', target, '--offline')
+        # Bundle extensions are defined by the CLI; include all build files to
+        # catch an unexpected full incremental rebuild regardless of extension.
+        files = {p: p.stat().st_mtime_ns for p in (project / 'build').rglob('*') if p.is_file()}
+        if not files:
+            raise RuntimeError('No build artifacts were produced')
+        invoke('package', str(project), '--aot-target', target, '--offline')
+        if any(p.stat().st_mtime_ns != stamp for p, stamp in files.items()):
+            raise RuntimeError('Incremental package rewrote build outputs')
+    invoke('publish', str(project), '--dry-run', '--offline')
+    if (project / 'micropixel.lock.json').read_bytes() != lock_before:
+        raise RuntimeError('Build/package/preflight modified the project lock')
+    powershell = Path(os.environ['WINDIR']) / 'System32/WindowsPowerShell/v1.0/powershell.exe'
+    command = [str(powershell), '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File',
+               str(ROOT / 'tools/windows/test_acceptance_versions.ps1'), '-Launcher', str(launcher),
+               '-Directory', str(root / 'A B acceptance')]
+    if not args.public:
+        command.append('-OfflineFixtures')
+    subprocess.run(command, env=env, check=True, timeout=900)
+    report = {'schema_version': 1, 'ok': True, 'stage': 'public' if args.public else 'draft',
+              'sdk_version': version, 'toolchain_id': doctor['result']['toolchain_id'],
+              'targets': ['riscv32-ilp32f', 'xtensa'], 'windows_10_manual_acceptance': 'pending'}
+    (out / ('public-verification.json' if args.public else 'draft-verification.json')).write_text(json.dumps(report, indent=2) + '\n')
+    print(json.dumps(report))
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/windows/verify_installed_sdk.py
+++ b/tools/windows/verify_installed_sdk.py
@@ -23,7 +23,7 @@ def main():
     out = args.directory.resolve()
     entry = json.loads((out / 'channel-entry.json').read_text())
     version = entry['version']
-    root = Path(os.environ['RUNNER_TEMP']) / ('mp-public' if args.public else 'mp-draft')
+    root = Path(os.environ['RUNNER_TEMP']) / ('mp-public 中文' if args.public else 'mp-draft 中文')
     if root.exists():
         raise SystemExit('Integration requires a fresh cache')
     root.mkdir()
@@ -32,7 +32,7 @@ def main():
     env.update(MICROPIXEL_HOME=str(root), MICROPIXEL_SDK_INDEX_URL=entry['entry']['url'].rsplit('/', 1)[0] + '/test-sdk-index.json')
     # Native tools must not accidentally find CI's Python/Git/CMake/LLVM/CRT.
     env['PATH'] = str(Path(env['WINDIR']) / 'System32')
-    for key in ('WASI_SDK_PATH', 'WASI_CLANG', 'WASI_CLANGXX', 'WAMRC', 'XTENSA_WAMRC', 'PYTHONPATH', 'PYTHONHOME'):
+    for key in ('WASI_SDK_PATH', 'WASI_CLANG', 'WASI_CLANGXX', 'WAMRC', 'XTENSA_WAMRC', 'PYTHONPATH', 'PYTHONHOME', 'PSModulePath'):
         env.pop(key, None)
     index = json.loads((out / 'test-sdk-index.json').read_text())
     if not args.public:
@@ -65,7 +65,7 @@ def main():
             raise RuntimeError(f'Installed command failed {command}: {result}')
         return result
 
-    invoke('setup', '--version', version, '--yes')
+    installed = invoke('setup', '--version', version, '--yes')['result']['paths']
     doctor = invoke('doctor', '--offline')
     if not doctor['result']['ready']:
         raise RuntimeError('Prepared tools did not pass doctor')
@@ -95,6 +95,13 @@ def main():
     invoke('publish', str(project), '--dry-run', '--offline')
     if (project / 'micropixel.lock.json').read_bytes() != lock_before:
         raise RuntimeError('Build/package/preflight modified the project lock')
+    # Exercise localization, audio generation and bundled resource files using
+    # only the published SDK's copies of the build helpers.
+    example = root / '素材 音效 示例'
+    shutil.copytree(Path(installed['sdk']) / 'guest/apps/blocks', example)
+    invoke('sdk', 'use', version, '--project', str(example), '--yes')
+    for target in ('riscv32-ilp32f', 'xtensa'):
+        invoke('package', str(example), '--aot-target', target, '--offline')
     powershell = Path(os.environ['WINDIR']) / 'System32/WindowsPowerShell/v1.0/powershell.exe'
     command = [str(powershell), '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File',
                str(ROOT / 'tools/windows/test_acceptance_versions.ps1'), '-Launcher', str(launcher),

--- a/tools/windows/verify_installed_sdk.py
+++ b/tools/windows/verify_installed_sdk.py
@@ -32,8 +32,15 @@ def main():
     env.update(MICROPIXEL_HOME=str(root), MICROPIXEL_SDK_INDEX_URL=entry['entry']['url'].rsplit('/', 1)[0] + '/test-sdk-index.json')
     # Native tools must not accidentally find CI's Python/Git/CMake/LLVM/CRT.
     env['PATH'] = str(Path(env['WINDIR']) / 'System32')
-    for key in ('WASI_SDK_PATH', 'WASI_CLANG', 'WASI_CLANGXX', 'WAMRC', 'XTENSA_WAMRC', 'PYTHONPATH', 'PYTHONHOME', 'PSModulePath'):
+    for key in ('WASI_SDK_PATH', 'WASI_CLANG', 'WASI_CLANGXX', 'WAMRC', 'XTENSA_WAMRC', 'PYTHONPATH', 'PYTHONHOME', 'PSMODULEPATH'):
         env.pop(key, None)
+    # os.environ normalizes Windows keys to uppercase. Keep only the system
+    # PowerShell 5.1 modules, not the parent PowerShell 7 module directory.
+    powershell_root = Path(os.environ['WINDIR']) / 'System32/WindowsPowerShell/v1.0'
+    env['PSMODULEPATH'] = str(powershell_root / 'Modules')
+    subprocess.run([str(powershell_root / 'powershell.exe'), '-NoProfile', '-Command',
+                    'Get-Command Get-FileHash -ErrorAction Stop | Select-Object -ExpandProperty Name'],
+                   env=env, check=True, timeout=30)
     index = json.loads((out / 'test-sdk-index.json').read_text())
     if not args.public:
         (root / 'manifests').mkdir()

--- a/tools/windows/verify_installed_sdk.py
+++ b/tools/windows/verify_installed_sdk.py
@@ -109,6 +109,11 @@ def main():
     invoke('sdk', 'use', version, '--project', str(example), '--yes')
     for target in ('riscv32-ilp32f', 'xtensa'):
         invoke('package', str(example), '--aot-target', target, '--offline')
+    fixture = root / '真机 验收 App'
+    shutil.copytree(ROOT / 'tools/windows/fixtures/acceptance', fixture)
+    invoke('sdk', 'use', version, '--project', str(fixture), '--yes')
+    for target in ('riscv32-ilp32f', 'xtensa'):
+        invoke('package', str(fixture), '--aot-target', target, '--offline')
     powershell = Path(os.environ['WINDIR']) / 'System32/WindowsPowerShell/v1.0/powershell.exe'
     command = [str(powershell), '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File',
                str(ROOT / 'tools/windows/test_acceptance_versions.ps1'), '-Launcher', str(launcher),


### PR DESCRIPTION
The Windows Preview now verifies the actual installed SDK before publication. The workflow creates an immutable Draft, publishes a Preview, repeats verification from public downloads in a fresh cache, and only then promotes the dedicated SDK channel. The installer carries its exact SDK manifest so it can prepare that version independently of channel promotion.

Installed testing uncovered and fixes two Windows issues: the pinned WAMRC cannot consume Unicode absolute filenames, and embedding the Bundle builder in `python -c` exceeded the Windows command-line limit. The CLI stages AOT inputs with ASCII names and distributes packaging helpers as UTF-8 script files. Missing targets/devices produce actionable input/environment exit codes; stable upgrades cannot downgrade newer project locks.

The Release includes isolated A/B SDK and manager fixtures, user/AI guides, W01–W19 acceptance instructions, a redacted report collector, and a small touch/key/logging App for both device architectures. Preview publication cannot change the stable SDK pointer; signing and Windows 10/physical-device acceptance remain outstanding.

Validation:
- Complete installed Windows SDK integration passed in run 34528861850, including GUI installer payload/silent lifecycle, Unicode paths and caches, dual-target compilation, resources/audio/localization, header invalidation, publish dry-run, A/B rollback, and manager switching.
- 98 local CLI/manager/archive regressions and `bash tools/p4.sh test` passed.
- The standalone SDK archive built SDK Demo on macOS; the device acceptance project packaged for both RISC-V and Xtensa locally.
- This PR repeats Windows verification including the newly attached device acceptance project. No physical-device or interactive Windows 10 pass is claimed.
